### PR TITLE
#467: Culture-sensitive ToLower() usage in ToLogsLevel method

### DIFF
--- a/src/FlowSynx.Application/Features/Logs/Query/LogsList/LogsListHandler.cs
+++ b/src/FlowSynx.Application/Features/Logs/Query/LogsList/LogsListHandler.cs
@@ -65,11 +65,11 @@ internal class LogsListHandler : IRequestHandler<LogsListRequest, Result<IEnumer
 
     private static LogsLevel ToLogsLevel(string logsLevel)
     {
-        if (!Enum.TryParse<LogsLevel>(logsLevel, ignoreCase: true, out var result))
+        if (!Enum.TryParse<LogsLevel>(logsLevel, ignoreCase: true, out var level))
         {
             return LogsLevel.Info;
         }
 
-        return result;
+        return level;
     }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Replaced the culture-sensitive `ToLower()` call in `ToLogsLevel(string logsLevel)` with a case-insensitive `Enum.TryParse` approach. 

## Issue reference

Closes #467 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in the https://github.com/flowsynx/website/#[issue number]
* [ ] Specification has been updated / Created issue in the https://github.com/flowsynx/website/#[issue number]
* [ ] Provided sample for the feature / Created issue in the https://github.com/flowsynx/website/#[issue number]

There do not appear to be any (unit) tests covering this class currently. Please point me to them or let me know if you would like me to add them.
