### PR TITLE
Add default branch to audit switch

### DIFF
--- a/src/FlowSynx.Persistence.Postgres/Contexts/AuditableContext.cs
+++ b/src/FlowSynx.Persistence.Postgres/Contexts/AuditableContext.cs
@@ -63,6 +63,10 @@ public abstract class AuditableContext(DbContextOptions options) : DbContext(opt
                             auditEntry.NewValues[propertyName] = property.CurrentValue!;
                         }
                         break;
+
+                    default:
+                        // No action required for other states
+                        break;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a defensive `default` branch in `AuditableContext.OnBeforeSaveChanges`

## Testing
- not run

Closes #501