### PR TITLE
Add default branch to placeholder switch

### DIFF
--- a/src/FlowSynx.Infrastructure/Workflow/PlaceholderReplacer.cs
+++ b/src/FlowSynx.Infrastructure/Workflow/PlaceholderReplacer.cs
@@ -102,6 +102,9 @@ public class PlaceholderReplacer : IPlaceholderReplacer
             case JArray jArray:
                 ReplacePlaceholderInJArray(jArray, parser);
                 break;
+            default:
+                // No action needed for other types
+                break;
         }
     }
 


### PR DESCRIPTION
## Summary
- add a defensive `default` branch in `PlaceholderReplacer.ReplacePlaceholderInJson`

## Testing
- not run

Closes #500