### PR TITLE
Use RandomNumberGenerator in jitter backoff

### DIFF
--- a/src/FlowSynx.Infrastructure/Workflow/BackoffStrategies/JitterBackoffStrategy.cs
+++ b/src/FlowSynx.Infrastructure/Workflow/BackoffStrategies/JitterBackoffStrategy.cs
@@ -1,13 +1,21 @@
-﻿namespace FlowSynx.Infrastructure.Workflow.BackoffStrategies;
+﻿using System.Security.Cryptography;
+
+namespace FlowSynx.Infrastructure.Workflow.BackoffStrategies;
 
 public class JitterBackoffStrategy(int initialDelay, double backoffCoefficient = 0.5) : IBackoffStrategy
 {
-    private readonly Random _random = new();
-
     public TimeSpan GetDelay(int retryCount)
     {
         var baseMs = initialDelay * Math.Pow(2, retryCount); // Exponential growth
-        var jitter = _random.NextDouble() * backoffCoefficient * baseMs;
+        var jitter = GetRandomFraction() * backoffCoefficient * baseMs;
         return TimeSpan.FromMilliseconds(baseMs + jitter);
+    }
+
+    private static double GetRandomFraction()
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        RandomNumberGenerator.Fill(buffer);
+        var randomValue = BitConverter.ToUInt64(buffer);
+        return randomValue / (ulong.MaxValue + 1.0);
     }
 }

--- a/tests/FlowSynx.Infrastructure.UnitTests/Workflow/BackoffStrategies/JitterBackoffStrategyTests.cs
+++ b/tests/FlowSynx.Infrastructure.UnitTests/Workflow/BackoffStrategies/JitterBackoffStrategyTests.cs
@@ -1,0 +1,36 @@
+﻿using FlowSynx.Infrastructure.Workflow.BackoffStrategies;
+
+namespace FlowSynx.Infrastructure.UnitTests.Workflow.BackoffStrategies;
+
+public class JitterBackoffStrategyTests
+{
+    [Fact]
+    public void GetDelay_ReturnsBaseDelay_WhenCoefficientIsZero()
+    {
+        var strategy = new JitterBackoffStrategy(initialDelay: 100, backoffCoefficient: 0);
+        var retryCount = 3;
+        var expected = TimeSpan.FromMilliseconds(100 * Math.Pow(2, retryCount));
+
+        var delay = strategy.GetDelay(retryCount);
+
+        Assert.Equal(expected, delay);
+    }
+
+    [Fact]
+    public void GetDelay_RemainsWithinExpectedRange()
+    {
+        var initialDelay = 50;
+        var backoffCoefficient = 0.5;
+        var strategy = new JitterBackoffStrategy(initialDelay, backoffCoefficient);
+        var retryCount = 4;
+
+        var baseMs = initialDelay * Math.Pow(2, retryCount);
+        var maxMs = baseMs * (1 + backoffCoefficient);
+
+        for (var i = 0; i < 10; i++)
+        {
+            var delay = strategy.GetDelay(retryCount);
+            Assert.InRange(delay.TotalMilliseconds, baseMs, maxMs);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor jitter backoff to use RandomNumberGenerator
- add tests covering base delay and jitter bounds

## Testing
- not run (dotnet cli missing in environment)

Closes #498