### PR TITLE
Add task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,21 @@
+---
+name: Task
+about: Track a discrete unit of work such as refactors, chores, or follow-ups
+title: ''
+labels: task
+assignees: ''
+
+---
+
+## Summary
+Provide a clear, action-oriented description of the work to be done.
+
+## Motivation
+Explain why this task matters and what problem it will solve.
+
+## Acceptance Criteria
+- [ ] Describe measurable outcomes that signal completion
+- [ ] Include any edge cases or follow-up verifications
+
+## Additional Context
+List related issues, links, or notes that will help the assignee deliver this task.


### PR DESCRIPTION
## Summary
- add a dedicated Task issue template so contributors can capture scoped pieces of work
- pre-populate sections for summary, motivation, acceptance criteria, and contextual links to improve clarity
- ensure Task issues default to the `task` label so the template appears correctly in the new issue chooser

## Testing
- not run (documentation only)

Closes #474