### PR TITLE
Add build-from-source quickstart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,30 @@ Ready to try FlowSynx? Start automating in minutes.
 📘 **Documentation:** [Getting Started Guide](https://flowsynx.io/docs/getting-started)  
 🧩 **Samples:** [Example Workflows & Configs](https://github.com/flowsynx/samples)  
 
+## Build from Source
+
+Want to contribute or run FlowSynx locally? Use this quickstart to build from source in minutes.
+
+### Prerequisites
+
+- [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) — confirm with `dotnet --version` (should report 9.x)
+- Git
+
+### Quickstart
+
+```bash
+git clone https://github.com/flowsynx/flowsynx
+cd flowsynx
+dotnet restore
+dotnet build --configuration Release
+dotnet test
+```
+
+- Commands are cross-platform (Windows, Linux, macOS).
+- Build artifacts land in each project's `bin/Release` directory.
+
+For advanced workflows (Docker, local environment setup, contributing guidelines), see [CONTRIBUTING.md](https://github.com/flowsynx/flowsynx/blob/master/CONTRIBUTING.md).
+
 ## Architecture Overview
 
 <img src="/img/architecture-diagram.jpg" alt="FlowSynx Architecture Diagram"/>
@@ -160,30 +184,6 @@ You can:
 - 🌍 Collaborate in discussions  
 
 👉 See [CONTRIBUTING.md](https://github.com/flowsynx/flowsynx/blob/master/CONTRIBUTING.md)
-
-## Build from Source
-
-Want to contribute or run FlowSynx locally? Use this quickstart to build from source in minutes.
-
-### Prerequisites
-
-- [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0) — confirm with `dotnet --version` (should report 9.x)
-- Git
-
-### Quickstart
-
-```bash
-git clone https://github.com/flowsynx/flowsynx
-cd flowsynx
-dotnet restore
-dotnet build --configuration Release
-dotnet test
-```
-
-- Commands are cross-platform (Windows, Linux, macOS).
-- Build artifacts land in each project's `bin/Release` directory.
-
-For advanced workflows (Docker, local environment setup, contributing guidelines), see [CONTRIBUTING.md](https://github.com/flowsynx/flowsynx/blob/master/CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
## Summary
- introduce a Build from Source section in the README so contributors can build locally
- capture prerequisites (.NET 9 SDK and Git) and provide cross-platform restore/build/test commands
- direct readers to CONTRIBUTING.md for deeper setup guidance

## Testing
- not run (documentation only)

Closes #485