### PR TITLE
Tidy PR template issue references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Please explain the changes you've made.
 We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
 -->
 
-Please reference the issue this PR will close: #_[issue number]_
+Closes #<issue-number>
 
 ## Checklist
 
@@ -28,6 +28,6 @@ Please make sure you've  completed the relevant tasks for this PR, out of the fo
 * [ ] Created/updated tests
 * [ ] Unit tests passing
 * [ ] End-to-end tests passing
-* [ ] Extended the documentation / Created issue in the https://github.com/flowsynx/website/ #_[issue number]_
-* [ ] Specification has been updated / Created issue in the https://github.com/flowsynx/website/ #_[issue number]_
-* [ ] Provided sample for the feature / Created issue in the https://github.com/flowsynx/website/ #_[issue number]_
+* [ ] Extended the documentation / Created issue in flowsynx/website#<issue-number>
+* [ ] Specification has been updated / Created issue in flowsynx/website#<issue-number>
+* [ ] Provided sample for the feature / Created issue in flowsynx/website#<issue-number>


### PR DESCRIPTION
## Summary
- update the PR template to direct authors to use the `Closes #<issue-number>` syntax
- fix website issue placeholders so they render as `flowsynx/website#<issue-number>`

## Testing
- not run (documentation only)

Closes #473