### PR TITLE
chore(ci): pin docker login action to full sha

### DIFF
--- a/.github/workflows/flowsynx-release.yml
+++ b/.github/workflows/flowsynx-release.yml
@@ -157,7 +157,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        # docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## Summary
- pin `docker/login-action` to the long SHA `5e57cd118135c172c3672efd75eb46360885c0ef` backing the v3 release
- annotate the step with the historical tag to keep future upgrades straightforward

## Testing
- not run (GitHub Actions workflow change only)

## Security
- mitigates supply-chain drift by ensuring the release workflow authenticates with an immutable action revision

Closes #517.
