### PR TITLE
Refactor repeated GUID validation into shared extension

### DIFF
--- a/src/FlowSynx.Application/Extensions/ValidatorExtensions.cs
+++ b/src/FlowSynx.Application/Extensions/ValidatorExtensions.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace FlowSynx.Application.Extensions;
+
+public static class ValidatorExtensions
+{
+    public static IRuleBuilderOptions<T, string> MustBeValidGuid<T>(
+        this IRuleBuilder<T, string> ruleBuilder,
+        string message)
+    {
+        ArgumentNullException.ThrowIfNull(ruleBuilder);
+        ArgumentNullException.ThrowIfNull(message);
+
+        return ruleBuilder
+            .Must(id => Guid.TryParse(id, out _))
+            .WithMessage(message);
+    }
+}
+

--- a/src/FlowSynx.Application/Features/Audit/Query/AuditDetails/AuditDetailsValidator.cs
+++ b/src/FlowSynx.Application/Features/Audit/Query/AuditDetails/AuditDetailsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Audit.Query.AuditDetails;
@@ -13,12 +14,6 @@ public class AuditDetailsValidator : AbstractValidator<AuditDetailsRequest>
             .WithMessage(localization.Get("Features_Validation_AuditId_MustHaveValue"));
 
         RuleFor(x => x.AuditId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_AuditId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_AuditId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/PluginConfig/Command/DeletePluginConfig/DeletePluginConfigValidator.cs
+++ b/src/FlowSynx.Application/Features/PluginConfig/Command/DeletePluginConfig/DeletePluginConfigValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.PluginConfig.Command.DeletePluginConfig;
@@ -13,12 +14,6 @@ public class DeletePluginConfigValidator : AbstractValidator<DeletePluginConfigR
             .WithMessage(localization.Get("Features_Validation_PluginConfigId_MustHaveValue"));
 
         RuleFor(x => x.ConfigId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_PluginConfigId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_PluginConfigId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/PluginConfig/Command/UpdatePluginConfig/UpdatePluginConfigValidator.cs
+++ b/src/FlowSynx.Application/Features/PluginConfig/Command/UpdatePluginConfig/UpdatePluginConfigValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.PluginConfig.Command.UpdatePluginConfig;
@@ -13,8 +14,7 @@ public class UpdatePluginConfigValidator : AbstractValidator<UpdatePluginConfigR
             .WithMessage(localization.Get("Features_Validation_PluginConfigId_MustHaveValue"));
 
         RuleFor(x => x.ConfigId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_PluginConfigId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_PluginConfigId_InvalidGuidFormat"));
 
         RuleFor(request => request.Name)
             .NotNull()
@@ -34,10 +34,5 @@ public class UpdatePluginConfigValidator : AbstractValidator<UpdatePluginConfigR
             .NotNull()
             .NotEmpty()
             .WithMessage(localization.Get("Features_Validation_PluginConfig_Version_MustHaveValue"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
     }
 }

--- a/src/FlowSynx.Application/Features/PluginConfig/Query/PluginConfigDetails/PluginConfigDetailsValidator.cs
+++ b/src/FlowSynx.Application/Features/PluginConfig/Query/PluginConfigDetails/PluginConfigDetailsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.PluginConfig.Query.PluginConfigDetails;
@@ -13,12 +14,6 @@ public class PluginConfigDetailsValidator : AbstractValidator<PluginConfigDetail
             .WithMessage(localization.Get("Features_Validation_PluginConfigId_MustHaveValue"));
 
         RuleFor(x => x.ConfigId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_PluginConfigId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_PluginConfigId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/Plugins/Query/PluginDetails/PluginDetailsValidator.cs
+++ b/src/FlowSynx.Application/Features/Plugins/Query/PluginDetails/PluginDetailsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Plugins.Query.PluginDetails;
@@ -13,12 +14,6 @@ public class PluginDetailsValidator : AbstractValidator<PluginDetailsRequest>
             .WithMessage(localization.Get("Features_Validation_PluginId_MustHaveValue"));
 
         RuleFor(x => x.PluginId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_PluginId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_PluginId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Command/ApproveWorkflow/ApproveWorkflowValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Command/ApproveWorkflow/ApproveWorkflowValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Command.ApproveWorkflow;
@@ -13,16 +14,9 @@ public class ApproveWorkflowValidator : AbstractValidator<ApproveWorkflowRequest
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.WorkflowExecutionApprovalId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Command/CancelWorkflow/CancelWorkflowValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Command/CancelWorkflow/CancelWorkflowValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Command.CancelWorkflow;
@@ -13,12 +14,6 @@ public class CancelWorkflowValidator : AbstractValidator<CancelWorkflowRequest>
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Command/RejectWorkflow/RejectWorkflowValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Command/RejectWorkflow/RejectWorkflowValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Command.RejectWorkflow;
@@ -13,16 +14,9 @@ public class RejectWorkflowValidator : AbstractValidator<RejectWorkflowRequest>
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.WorkflowExecutionApprovalId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionApprovals/WorkflowExecutionApprovalsValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionApprovals/WorkflowExecutionApprovalsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Query.WorkflowExecutionApprovals;
@@ -13,8 +14,7 @@ public class WorkflowExecutionApprovalsValidator : AbstractValidator<WorkflowExe
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.WorkflowExecutionId)
             .NotNull()
@@ -22,12 +22,6 @@ public class WorkflowExecutionApprovalsValidator : AbstractValidator<WorkflowExe
             .WithMessage(localization.Get("Features_Validation_ExecutionId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionDetails/WorkflowExecutionDetailsValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionDetails/WorkflowExecutionDetailsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Query.WorkflowExecutionDetails;
@@ -13,8 +14,7 @@ public class WorkflowExecutionDetailsValidator : AbstractValidator<WorkflowExecu
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.WorkflowExecutionId)
             .NotNull()
@@ -22,12 +22,6 @@ public class WorkflowExecutionDetailsValidator : AbstractValidator<WorkflowExecu
             .WithMessage(localization.Get("Features_Validation_ExecutionId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionList/WorkflowExecutionListValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionList/WorkflowExecutionListValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Query.WorkflowExecutionList;
@@ -13,12 +14,6 @@ public class WorkflowExecutionListValidator : AbstractValidator<WorkflowExecutio
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionLogs/WorkflowExecutionLogsValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionLogs/WorkflowExecutionLogsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Query.WorkflowExecutionLogs;
@@ -13,8 +14,7 @@ public class WorkflowExecutionLogsValidator : AbstractValidator<WorkflowExecutio
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.WorkflowExecutionId)
             .NotNull()
@@ -22,12 +22,6 @@ public class WorkflowExecutionLogsValidator : AbstractValidator<WorkflowExecutio
             .WithMessage(localization.Get("Features_Validation_ExecutionId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionTasks/WorkflowExecutionTasksValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowExecutionTasks/WorkflowExecutionTasksValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Query.WorkflowExecutionTasks;
@@ -13,8 +14,7 @@ public class WorkflowExecutionTasksValidator : AbstractValidator<WorkflowExecuti
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.WorkflowExecutionId)
             .NotNull()
@@ -22,12 +22,6 @@ public class WorkflowExecutionTasksValidator : AbstractValidator<WorkflowExecuti
             .WithMessage(localization.Get("Features_Validation_ExecutionId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowTaskExecutionDetails/WorkflowTaskExecutionDetailsValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowTaskExecutionDetails/WorkflowTaskExecutionDetailsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Query.WorkflowTaskExecutionDetails;
@@ -13,8 +14,7 @@ public class WorkflowTaskExecutionDetailsValidator : AbstractValidator<WorkflowT
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.WorkflowExecutionId)
             .NotNull()
@@ -22,12 +22,6 @@ public class WorkflowTaskExecutionDetailsValidator : AbstractValidator<WorkflowT
             .WithMessage(localization.Get("Features_Validation_ExecutionId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowTaskExecutionLogs/WorkflowTaskExecutionLogsValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowExecutions/Query/WorkflowTaskExecutionLogs/WorkflowTaskExecutionLogsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.WorkflowExecutions.Query.WorkflowTaskExecutionLogs;
@@ -13,8 +14,7 @@ public class WorkflowTaskExecutionLogsValidator : AbstractValidator<WorkflowTask
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.WorkflowExecutionId)
             .NotNull()
@@ -22,12 +22,6 @@ public class WorkflowTaskExecutionLogsValidator : AbstractValidator<WorkflowTask
             .WithMessage(localization.Get("Features_Validation_ExecutionId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowExecutionId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_ExecutionId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowTriggers/Command/AddWorkflowTrigger/AddWorkflowTriggerValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowTriggers/Command/AddWorkflowTrigger/AddWorkflowTriggerValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Workflows.Command.AddWorkflowTrigger;
@@ -13,12 +14,6 @@ public class AddWorkflowTriggerValidator : AbstractValidator<AddWorkflowTriggerR
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowTriggers/Command/DeleteWorkflowTrigger/DeleteWorkflowTriggerValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowTriggers/Command/DeleteWorkflowTrigger/DeleteWorkflowTriggerValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Workflows.Command.DeleteWorkflowTrigger;
@@ -13,8 +14,7 @@ public class DeleteWorkflowTriggerValidator : AbstractValidator<DeleteWorkflowTr
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.TriggerId)
             .NotNull()
@@ -22,12 +22,6 @@ public class DeleteWorkflowTriggerValidator : AbstractValidator<DeleteWorkflowTr
             .WithMessage(localization.Get("Features_Validation_TriggerId_MustHaveValue"));
 
         RuleFor(x => x.TriggerId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_TriggerId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_TriggerId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowTriggers/Command/UpdateWorkflowTrigger/UpdateWorkflowTriggerValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowTriggers/Command/UpdateWorkflowTrigger/UpdateWorkflowTriggerValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Workflows.Command.UpdateWorkflowTrigger;
@@ -13,8 +14,7 @@ public class UpdateWorkflowTriggerValidator : AbstractValidator<UpdateWorkflowTr
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.TriggerId)
             .NotNull()
@@ -22,12 +22,6 @@ public class UpdateWorkflowTriggerValidator : AbstractValidator<UpdateWorkflowTr
             .WithMessage(localization.Get("Features_Validation_TriggerId_MustHaveValue"));
 
         RuleFor(x => x.TriggerId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_TriggerId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_TriggerId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowTriggers/Query/WorkflowTriggerDetails/WorkflowTriggerDetailsValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowTriggers/Query/WorkflowTriggerDetails/WorkflowTriggerDetailsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Workflows.Query.WorkflowTriggerDetails;
@@ -13,8 +14,7 @@ public class WorkflowTriggerDetailsValidator : AbstractValidator<WorkflowTrigger
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.TriggerId)
             .NotNull()
@@ -22,12 +22,6 @@ public class WorkflowTriggerDetailsValidator : AbstractValidator<WorkflowTrigger
             .WithMessage(localization.Get("Features_Validation_TriggerId_MustHaveValue"));
 
         RuleFor(x => x.TriggerId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_TriggerId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_TriggerId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/WorkflowTriggers/Query/WorkflowTriggersList/WorkflowTriggersListValidator.cs
+++ b/src/FlowSynx.Application/Features/WorkflowTriggers/Query/WorkflowTriggersList/WorkflowTriggersListValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Workflows.Query.WorkflowTriggersList;
@@ -13,12 +14,6 @@ public class WorkflowTriggersListValidator : AbstractValidator<WorkflowTriggersL
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/Workflows/Command/DeleteWorkflow/DeleteWorkflowValidator.cs
+++ b/src/FlowSynx.Application/Features/Workflows/Command/DeleteWorkflow/DeleteWorkflowValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Workflows.Command.DeleteWorkflow;
@@ -13,12 +14,6 @@ public class DeleteWorkflowValidator : AbstractValidator<DeleteWorkflowRequest>
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
     }
 }

--- a/src/FlowSynx.Application/Features/Workflows/Command/UpdateWorkflow/UpdateWorkflowValidator.cs
+++ b/src/FlowSynx.Application/Features/Workflows/Command/UpdateWorkflow/UpdateWorkflowValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Workflows.Command.UpdateWorkflow;
@@ -13,16 +14,10 @@ public class UpdateWorkflowValidator : AbstractValidator<UpdateWorkflowRequest>
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
 
         RuleFor(x => x.SchemaUrl)
             .Must(value => value is null || string.IsNullOrWhiteSpace(value) || Uri.TryCreate(value, UriKind.Absolute, out _))
             .WithMessage(localization.Get("Features_Workflow_Validation_SchemaUrl_Invalid"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
     }
 }

--- a/src/FlowSynx.Application/Features/Workflows/Query/WorkflowDetails/WorkflowDetailsValidator.cs
+++ b/src/FlowSynx.Application/Features/Workflows/Query/WorkflowDetails/WorkflowDetailsValidator.cs
@@ -1,4 +1,5 @@
-﻿using FlowSynx.Application.Localizations;
+﻿using FlowSynx.Application.Extensions;
+using FlowSynx.Application.Localizations;
 using FluentValidation;
 
 namespace FlowSynx.Application.Features.Workflows.Query.WorkflowDetails;
@@ -13,12 +14,6 @@ public class WorkflowDetailsValidator : AbstractValidator<WorkflowDetailsRequest
             .WithMessage(localization.Get("Features_Validation_WorkflowId_MustHaveValue"));
 
         RuleFor(x => x.WorkflowId)
-            .Must(BeAValidGuid)
-            .WithMessage(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
-    }
-
-    private bool BeAValidGuid(string id)
-    {
-        return Guid.TryParse(id, out _);
+            .MustBeValidGuid(localization.Get("Features_Validation_WorkflowId_InvalidGuidFormat"));
     }
 }

--- a/tests/FlowSynx.Application.UnitTests/Extensions/ValidatorExtensionsTests.cs
+++ b/tests/FlowSynx.Application.UnitTests/Extensions/ValidatorExtensionsTests.cs
@@ -1,0 +1,62 @@
+using FlowSynx.Application.Extensions;
+using FluentValidation;
+
+namespace FlowSynx.Application.UnitTests.Extensions;
+
+public class ValidatorExtensionsTests
+{
+    private const string ErrorMessage = "Invalid GUID";
+
+    [Fact]
+    public void MustBeValidGuid_ValidGuid_PassesValidation()
+    {
+        // Arrange
+        var validator = new TestValidator(ErrorMessage);
+        var request = new TestRequest { Id = Guid.NewGuid().ToString() };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public void MustBeValidGuid_InvalidGuid_FailsWithProvidedMessage()
+    {
+        // Arrange
+        var validator = new TestValidator(ErrorMessage);
+        var request = new TestRequest { Id = "not-a-guid" };
+
+        // Act
+        var result = validator.Validate(request);
+
+        // Assert
+        Assert.False(result.IsValid);
+        var error = Assert.Single(result.Errors);
+        Assert.Equal(ErrorMessage, error.ErrorMessage);
+    }
+
+    [Fact]
+    public void MustBeValidGuid_NullMessage_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentNullException>(() => new TestValidator(null!));
+        Assert.Equal("message", exception.ParamName);
+    }
+
+    private sealed class TestRequest
+    {
+        public string Id { get; set; } = string.Empty;
+    }
+
+    private sealed class TestValidator : AbstractValidator<TestRequest>
+    {
+        public TestValidator(string message)
+        {
+            RuleFor(x => x.Id)
+                .MustBeValidGuid(message);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a reusable `MustBeValidGuid` FluentValidation extension under `FlowSynx.Application.Extensions`
- refactor every validator that previously duplicated `BeAValidGuid` to call the shared helper while keeping localized messages
- add focused unit tests that cover valid/invalid GUID paths and argument guards

## Testing
- dotnet test FlowSynx.sln

Fixes #536