### PR TITLE
Remove unused workflow trigger dependencies (#544, #545)

### DIFF
--- a/src/FlowSynx.Application/Features/WorkflowTriggers/Query/WorkflowTriggersList/WorkflowTriggersListHandler.cs
+++ b/src/FlowSynx.Application/Features/WorkflowTriggers/Query/WorkflowTriggersList/WorkflowTriggersListHandler.cs
@@ -1,10 +1,9 @@
 ﻿using FlowSynx.Application.Extensions;
 using FlowSynx.Application.Features.PluginConfig.Query.PluginConfigList;
 using FlowSynx.Application.Localizations;
-using FlowSynx.Application.Models;
+using FlowSynx.Domain.Trigger;
 using FlowSynx.Application.Services;
 using FlowSynx.Application.Wrapper;
-using FlowSynx.Domain.Trigger;
 using FlowSynx.PluginCore.Exceptions;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -16,14 +15,12 @@ internal class WorkflowTriggersListHandler : IRequestHandler<WorkflowTriggersLis
     private readonly ILogger<PluginConfigListHandler> _logger;
     private readonly IWorkflowTriggerService _workflowTriggerService;
     private readonly ICurrentUserService _currentUserService;
-    private readonly ISystemClock _systemClock;
     private readonly ILocalization _localization;
 
     public WorkflowTriggersListHandler(
         ILogger<PluginConfigListHandler> logger,
         IWorkflowTriggerService workflowTriggerService, 
         ICurrentUserService currentUserService,
-        ISystemClock systemClock,
         ILocalization localization)
     {
         ArgumentNullException.ThrowIfNull(logger);
@@ -33,7 +30,6 @@ internal class WorkflowTriggersListHandler : IRequestHandler<WorkflowTriggersLis
         _logger = logger;
         _workflowTriggerService = workflowTriggerService;
         _currentUserService = currentUserService;
-        _systemClock = systemClock;
         _localization = localization;
     }
 

--- a/src/FlowSynx.Infrastructure/Workflow/ResultStorageProviders/ResultStorageFactory.cs
+++ b/src/FlowSynx.Infrastructure/Workflow/ResultStorageProviders/ResultStorageFactory.cs
@@ -4,21 +4,18 @@ namespace FlowSynx.Infrastructure.Workflow.ResultStorageProviders;
 
 public class ResultStorageFactory: IResultStorageFactory
 {
-    private readonly IServiceProvider _serviceProvider;
     private readonly IDictionary<string, ResultStorageProviderConfiguration> _providerConfigs;
     private readonly IEnumerable<IResultStorageProvider> _providers;
     private readonly StorageConfiguration _config;
 
     public ResultStorageFactory(
-        IServiceProvider serviceProvider,
         StorageConfiguration config,
         IEnumerable<IResultStorageProvider> providers)
     {
-        _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
-        _providers = providers ?? throw new ArgumentNullException(nameof(serviceProvider));
         _config = config ?? throw new ArgumentNullException(nameof(config));
+        _providers = providers ?? throw new ArgumentNullException(nameof(providers));
 
-        _providerConfigs = config.ResultStorage.Providers
+        _providerConfigs = _config.ResultStorage.Providers
             .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
     }
 


### PR DESCRIPTION
## Summary
- Closes #544
- Closes #545

## What & Why 
- Removed the unused system clock dependency from the workflow triggers list handler so it only relies on the services it actually calls.
- Cleaned the associated using directives so the handler matches the rest of the application layering conventions.
- Dropped the unused service provider field from the result storage factory and kept the existing guard clauses focused on the remaining dependencies to reduce confusion for new contributors.

## Design Decisions
- Left the existing logging and pagination flow untouched to stay consistent with the surrounding handlers.
- Reordered the factory constructor assignments to keep null-checks and configuration logic aligned with the pattern used across infrastructure services.

## Testing
- `.dotnet/dotnet build FlowSynx.sln --configuration Release`
- `.dotnet/dotnet test FlowSynx.sln --configuration Release --no-build`

## Alignment
- Changes follow the repository's guard-clause pattern and reuse the existing localization and pagination utilities without introducing new abstractions.
- No new tests were required because existing unit coverage already exercises the affected entry points.
