### PR TITLE
Add roadmap section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Whether you’re streamlining **DevOps**, managing **data pipelines**, or buildi
 - [Runtime Context](#runtime-context)
 - [Why FlowSynx?](#why-flowsynx)
 - [Key Features](#key-features)
+- [Roadmap](#roadmap)
 - [Get Started using FlowSynx](#get-started-using-flowsynx)
 - [Architecture Overview](#architecture-overview)
   - [Interaction Layers](#interaction-layers)
@@ -115,6 +116,10 @@ Built on clean architecture principles, FlowSynx offers **clarity**, **control**
 ✅ **Error Handling** - Flexible Error Handling and Retry Policies per task and workflow level  
 ✅ **Marketplace & Registry** — Discover and manage plugins easily  
 ✅ **Web Console UI** — Intuitive dashboard for workflow monitoring and control  
+
+## Roadmap
+
+Curious about what’s next? Review the planned milestones in our [Roadmap](./docs/ROADMAP.md).
 
 ## Get Started using FlowSynx
 


### PR DESCRIPTION
## Summary
- add a roadmap section after Key Features while keeping the existing markdown voice
- link README to docs/ROADMAP.md so contributors can reach the milestone overview
- mirror the new section in the table of contents for consistent navigation

## Testing
- not run (docs only)

Closes #530.