### PR TITLE
Refactor: Make extract-zip-from-bytes static

### DIFF
--- a/src/FlowSynx.Infrastructure/PluginHost/Manager/PluginDownloader.cs
+++ b/src/FlowSynx.Infrastructure/PluginHost/Manager/PluginDownloader.cs
@@ -132,7 +132,7 @@ public class PluginDownloader : IPluginDownloader
         }
     }
 
-    private async Task ExtractZipFromBytesAsync(
+    private static async Task ExtractZipFromBytesAsync(
         string outputDirectory, 
         byte[] zipData, 
         CancellationToken cancellationToken)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description


I changed the `ExtractZipFromBytesAsync` method to static.


## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Closes #552 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in flowsynx/website#<issue-number>
* [ ] Specification has been updated / Created issue in flowsynx/website#<issue-number>
* [ ] Provided sample for the feature / Created issue in flowsynx/website#<issue-number>
