### PR TITLE
Fix: make ComputeCheckSum method static

### DIFF
--- a/src/FlowSynx.Infrastructure/PluginHost/Manager/PluginDownloader.cs
+++ b/src/FlowSynx.Infrastructure/PluginHost/Manager/PluginDownloader.cs
@@ -102,7 +102,7 @@ public class PluginDownloader : IPluginDownloader
         return computedChecksum.Equals(expectedChecksum, StringComparison.OrdinalIgnoreCase);
     }
 
-    private string ComputeChecksum(byte[] data)
+    private static string ComputeChecksum(byte[] data)
     {
         using SHA256 sha256 = SHA256.Create();
         var hashBytes = sha256.ComputeHash(data);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Changed `ComputeCheckSum(byte[] data)` to `static`.

## Issue reference


Closes #550 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in flowsynx/website#<issue-number>
* [ ] Specification has been updated / Created issue in flowsynx/website#<issue-number>
* [ ] Provided sample for the feature / Created issue in flowsynx/website#<issue-number>
