### PR TITLE
fix: Add a default clause to switch statement for value validation

### DIFF
--- a/src/FlowSynx.Infrastructure/PluginHost/PluginSpecificationsService.cs
+++ b/src/FlowSynx.Infrastructure/PluginHost/PluginSpecificationsService.cs
@@ -42,6 +42,9 @@ public class PluginSpecificationsService : IPluginSpecificationsService
                     case string when string.IsNullOrEmpty(value.ToString()):
                         valid = false;
                         break;
+                    default:
+                        valid = true;
+                        break;
                 }
 
                 if (valid) continue;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Added default clause in File: `src/FlowSynx.Infrastructure/PluginHost/PluginSpecificationsService.cs`

## Issue reference


Closes #568 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in flowsynx/website#<issue-number>
* [ ] Specification has been updated / Created issue in flowsynx/website#<issue-number>
* [ ] Provided sample for the feature / Created issue in flowsynx/website#<issue-number>
