### PR TITLE
fix: refactor FindFiles in DirectoryInfoExtensions

### DIFF
--- a/plugins/FlowSynx.Plugins.LocalFileSystem/Extensions/DirectoryInfoExtensions.cs
+++ b/plugins/FlowSynx.Plugins.LocalFileSystem/Extensions/DirectoryInfoExtensions.cs
@@ -20,7 +20,7 @@ internal static class DirectoryInfoExtensions
 
         foreach (var file in files)
         {
-            if(!ShouldIncludeFile(file,regex,listParameters))
+            if(!ShouldIncludeFile(file,regex))
                 continue;
             try 
             {            
@@ -59,7 +59,7 @@ internal static class DirectoryInfoExtensions
 
         return new Regex(listParameters.Filter, regexOptions);
     }
-    private static bool ShouldIncludeFile(FileInfo file, Regex? regex, ListParameters listParameters)
+    private static bool ShouldIncludeFile(FileInfo file, Regex? regex)
     {
         if(regex ==null)
             return true;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Refactored FindFiles method in `/plugins/FlowSynx.Plugins.LocalFileSystem/Extensions/DirectoryInfoExtensions.cs`

1.   Extracted FindFiles into smaller methods.
2.   Created methods `void ValidateDirectory(DirectoryInfo directoryInfo)` , `Regex? CreateRegex(ListParameters listParameters)` and `bool ShouldIncludeFile(FileInfo file, Regex? regex, ListParameters listParameters)`
3. Defined `resultCount ` outside for each loop.

## Issue reference


Closes #570 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in flowsynx/website#<issue-number>
* [ ] Specification has been updated / Created issue in flowsynx/website#<issue-number>
* [ ] Provided sample for the feature / Created issue in flowsynx/website#<issue-number>
