### PR TITLE
fix: increase log retrieval limit from 250 to 512

### DIFF
--- a/src/FlowSynx.Persistence.SQLite/Services/LoggerService.cs
+++ b/src/FlowSynx.Persistence.SQLite/Services/LoggerService.cs
@@ -28,7 +28,7 @@ public class LoggerService : ILoggerService
             {
                 return await logs
                     .OrderByDescending(x => x.TimeStamp)
-                    .Take(250)
+                    .Take(512)
                     .ToListAsync(cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
@@ -37,7 +37,7 @@ public class LoggerService : ILoggerService
                 return await logs
                     .Where(predicate)
                     .OrderByDescending(x => x.TimeStamp)
-                    .Take(250)
+                    .Take(512)
                     .ToListAsync(cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Increased log retrieval limit to 512 in `loggingService`

## Issue reference

Closes #574 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [x] Unit tests passing
* [x] End-to-end tests passing
* [ ] Extended the documentation / Created issue in flowsynx/website#<issue-number>
* [ ] Specification has been updated / Created issue in flowsynx/website#<issue-number>
* [ ] Provided sample for the feature / Created issue in flowsynx/website#<issue-number>
