### PR TITLE
Fix: align TriggerProcessingService token name

### DIFF
--- a/src/FlowSynx/Services/TriggerProcessingService.cs
+++ b/src/FlowSynx/Services/TriggerProcessingService.cs
@@ -15,7 +15,11 @@ public class TriggerProcessingService : BackgroundService
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
     }
 
-    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    /// <summary>
+    /// Coordinates trigger processors and runs until the host signals shutdown.
+    /// </summary>
+    /// <param name="stoppingToken">Token triggered when the host is stopping the service.</param>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("TriggerProcessingService started.");
 
@@ -23,7 +27,7 @@ public class TriggerProcessingService : BackgroundService
         var processors = initialScope.ServiceProvider.GetServices<IWorkflowTriggerProcessor>().ToList();
 
         // Launch each processor in its own background task
-        var processorTasks = processors.Select(p => RunProcessorAsync(p, cancellationToken)).ToList();
+        var processorTasks = processors.Select(p => RunProcessorAsync(p, stoppingToken)).ToList();
 
         await Task.WhenAll(processorTasks);
     }


### PR DESCRIPTION
## Summary
- Align the TriggerProcessingService override of `ExecuteAsync` with `BackgroundService` by renaming the cancellation token parameter to `stoppingToken`
- Update the downstream processor task creation to use the renamed token and add XML documentation clarifying the host-controlled shutdown semantics

## Rationale
- Matches the naming already used in other hosted services (e.g. WorkflowExecutionWorker) and the base class signature, keeping the codebase internally consistent
- Reinforces the intent of the token for future contributors by documenting how trigger processors are cancelled

## Testing
- `Dotnet test` *(blocked: dotnet CLI is not available in this environment)*

Fixes #594