### PR TITLE
Reduce LogTemplate.Format cognitive complexity (#592)

### DIFF
--- a/src/FlowSynx.Infrastructure/Logging/LogTemplate.cs
+++ b/src/FlowSynx.Infrastructure/Logging/LogTemplate.cs
@@ -9,56 +9,134 @@ namespace FlowSynx.Infrastructure.Logging;
 
 internal static class LogTemplate
 {
+    /// <summary>
+    /// Formats the provided template by replacing FlowSynx log tokens with <see cref="LogMessage"/> values.
+    /// </summary>
+    /// <param name="logMessage">The structured log payload supplying token values.</param>
+    /// <param name="template">The format template containing brace-delimited tokens.</param>
+    /// <returns>The fully rendered log line.</returns>
     internal static string Format(LogMessage logMessage, string template)
     {
         var sbResult = new StringBuilder(template.Length);
         var sbCurrentTerm = new StringBuilder();
-        var formatChars = template.ToCharArray();
         var inTerm = false;
 
-        for (var i = 0; i < template.Length; i++)
+        foreach (var character in template)
         {
-            if (formatChars[i] == '{')
-                inTerm = true;
-            else if (formatChars[i] == '}')
+            if (HandleOpeningBrace(character, ref inTerm))
             {
-                string? valueToAppend;
-                if (sbCurrentTerm.ToString() == "NewLine")
-                {
-                    valueToAppend = Environment.NewLine;
-                }
-                else
-                {
-                    var propertyInfo = logMessage
-                        .GetType()
-                        .GetProperty(sbCurrentTerm.ToString(), BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
-                    
-                    if (propertyInfo == null)
-                    {
-                        var message = Localization.Get("Logging_Invalid_Property", sbCurrentTerm);
-                        throw new FlowSynxException((int)ErrorCode.LoggerTemplateInvalidProperty, message);
-                    }
-
-                    var propertyValue = propertyInfo.GetValue(logMessage);
-
-                    if (string.Equals(propertyInfo.Name, "level", StringComparison.OrdinalIgnoreCase))
-                        propertyValue = GetShortLogLevel((LogLevel) propertyValue!);
-
-                    valueToAppend = propertyValue is null ? string.Empty : propertyValue.ToString();
-                }
-
-                sbResult.Append(valueToAppend);
-                sbCurrentTerm.Clear();
-                inTerm = false;
+                continue;
             }
-            else if (inTerm)
+
+            if (HandleClosingBrace(character, ref inTerm, sbCurrentTerm, sbResult, logMessage))
             {
-                sbCurrentTerm.Append(formatChars[i]);
+                continue;
             }
-            else
-                sbResult.Append(formatChars[i]);
+
+            AppendCharacter(character, inTerm, sbCurrentTerm, sbResult);
         }
+
         return sbResult.ToString();
+    }
+
+    /// <summary>
+    /// Detects the start of a token in the template.
+    /// </summary>
+    /// <param name="character">Current template character.</param>
+    /// <param name="inTerm">Template state indicating if we are inside a token.</param>
+    /// <returns>True when the character marks the start of a token and should not be appended.</returns>
+    private static bool HandleOpeningBrace(char character, ref bool inTerm)
+    {
+        if (character != '{')
+        {
+            return false;
+        }
+
+        inTerm = true;
+        return true;
+    }
+
+    /// <summary>
+    /// Finalises a token and writes the resolved value into the result buffer.
+    /// </summary>
+    /// <param name="character">Current template character.</param>
+    /// <param name="inTerm">Template state indicating if we are inside a token.</param>
+    /// <param name="sbCurrentTerm">Buffer accumulating token characters.</param>
+    /// <param name="sbResult">Rendered template output.</param>
+    /// <param name="logMessage">Message that supplies values for tokens.</param>
+    /// <returns>True when the character closes a token and processing is complete.</returns>
+    private static bool HandleClosingBrace(
+        char character,
+        ref bool inTerm,
+        StringBuilder sbCurrentTerm,
+        StringBuilder sbResult,
+        LogMessage logMessage)
+    {
+        if (character != '}')
+        {
+            return false;
+        }
+
+        var term = sbCurrentTerm.ToString();
+        var valueToAppend = GetValueForTerm(term, logMessage);
+
+        sbResult.Append(valueToAppend);
+        sbCurrentTerm.Clear();
+        inTerm = false;
+        return true;
+    }
+
+    /// <summary>
+    /// Routes the current character into the appropriate buffer based on template state.
+    /// </summary>
+    private static void AppendCharacter(
+        char character,
+        bool inTerm,
+        StringBuilder sbCurrentTerm,
+        StringBuilder sbResult)
+    {
+        if (inTerm)
+        {
+            sbCurrentTerm.Append(character);
+        }
+        else
+        {
+            sbResult.Append(character);
+        }
+    }
+
+    /// <summary>
+    /// Resolves a token name to a value sourced from the provided <see cref="LogMessage"/>.
+    /// </summary>
+    /// <param name="term">The token extracted from the template.</param>
+    /// <param name="logMessage">Message that supplies values for tokens.</param>
+    /// <returns>The resolved value, or an empty string when the value is null.</returns>
+    /// <exception cref="FlowSynxException">Thrown when the token does not map to a public log message property.</exception>
+    private static string GetValueForTerm(string term, LogMessage logMessage)
+    {
+        if (string.Equals(term, "NewLine", StringComparison.OrdinalIgnoreCase))
+        {
+            return Environment.NewLine;
+        }
+
+        var propertyInfo = logMessage
+            .GetType()
+            .GetProperty(term, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+
+        if (propertyInfo == null)
+        {
+            var message = Localization.Get("Logging_Invalid_Property", term);
+            throw new FlowSynxException((int)ErrorCode.LoggerTemplateInvalidProperty, message);
+        }
+
+        var propertyValue = propertyInfo.GetValue(logMessage);
+
+        if (string.Equals(propertyInfo.Name, "level", StringComparison.OrdinalIgnoreCase))
+        {
+            propertyValue = GetShortLogLevel((LogLevel)propertyValue!);
+        }
+
+        return propertyValue?.ToString() ?? string.Empty;
     }
 
     internal static string GetShortLogLevel(LogLevel logLevel)


### PR DESCRIPTION
## Summary
- Refactors `LogTemplate.Format` into focused helpers to cut the cognitive complexity below the 15 point threshold described in #592
- Documents the new workflow with XML doc comments so maintainers can quickly understand the formatting pipeline
- keeps the existing log level short-name mapping and localisation behaviour so downstream components remain untouched

## Implementation Details
- Rewrote the formatting loop to iterate characters using a state machine while delegating opening brace detection, closing brace resolution, and character routing to dedicated helpers
- Introduced `HandleOpeningBrace`, `HandleClosingBrace`, `AppendCharacter`, and `GetValueForTerm` to encapsulate the responsibilities previously mixed inside `Format`
- Added XML documentation summaries to the refactored methods to align with the guidance in `CONTRIBUTING.md` regarding maintainable, well-documented code
- Preserved localisation-based error handling by raising the same `FlowSynxException` when an unknown token is encountered, ensuring compatibility with existing telemetry and alerts

## Testing
- `dotnet test` *(blocked: `dotnet` CLI is not available in the current CLI environment)*

Closes #592.