### PR TITLE
Refactor: make TryAddJsonArrayRoles static

### DIFF
--- a/src/FlowSynx/Security/RoleClaimsTransformation.cs
+++ b/src/FlowSynx/Security/RoleClaimsTransformation.cs
@@ -59,7 +59,7 @@ public class RoleClaimsTransformation : IClaimsTransformation
     /// <param name="identity">Identity that holds the raw claim set.</param>
     /// <param name="claimType">The claim type being evaluated for roles.</param>
     /// <param name="roles">Role accumulator that guards against duplicates.</param>
-    private void AddRolesFromClaim(ClaimsIdentity identity, string claimType, HashSet<string> roles)
+    private static void AddRolesFromClaim(ClaimsIdentity identity, string claimType, HashSet<string> roles)
     {
         foreach (var claim in identity.FindAll(claimType))
         {
@@ -83,7 +83,7 @@ public class RoleClaimsTransformation : IClaimsTransformation
     /// <param name="claimValue">The raw claim value.</param>
     /// <param name="roles">Role accumulator.</param>
     /// <returns>True if roles were added from a JSON array payload; otherwise false.</returns>
-    private bool TryAddJsonArrayRoles(string claimValue, HashSet<string> roles)
+    private static bool TryAddJsonArrayRoles(string claimValue, HashSet<string> roles)
     {
         if (!IsJsonArray(claimValue))
         {


### PR DESCRIPTION
## Summary
- Convert TryAddJsonArrayRoles to a static helper to reflect that the routine does not depend on instance state.
- Keep existing JSON parsing flow and documentation consistent with neighbouring helpers such as IsJsonArray.

## Implementation Notes
- The helper already avoided instance members; marking it static improves readability and mirrors other stateless helpers in RoleClaimsTransformation.
- No functional behaviour changes were introduced; parsing, error handling, and role aggregation remain identical to the pre-refactor code path.

## Testing
- dotnet test FlowSynx.sln *(not run: .NET SDK is unavailable in the current environment)*

Closes #605.