### PR TITLE
Refactor: align Logs rate limit parameter name

### DIFF
--- a/src/FlowSynx/Endpoints/Logs.cs
+++ b/src/FlowSynx/Endpoints/Logs.cs
@@ -9,10 +9,15 @@ namespace FlowSynx.Endpoints;
 
 public class Logs : EndpointGroupBase
 {
-    public override void Map(WebApplication app, string rateLimitPolicy)
+    /// <summary>
+    /// Register the logs endpoints and apply the configured rate-limiting policy.
+    /// </summary>
+    /// <param name="app">Application builder used to define endpoints.</param>
+    /// <param name="rateLimitPolicyName">Named rate-limiting policy applied to this group.</param>
+    public override void Map(WebApplication app, string rateLimitPolicyName)
     {
         var group = app.MapGroup(this)
-                       .RequireRateLimiting(rateLimitPolicy);
+                       .RequireRateLimiting(rateLimitPolicyName);
 
         group.MapPost("", LogsList)
             .WithName("LogsList")


### PR DESCRIPTION
## Summary
- Rename the Map override parameter to ateLimitPolicyName so it matches the signature defined on EndpointGroupBase.
- Update the internal usage to reference the renamed parameter when attaching the rate-limiting policy.
- Document the override to clarify how the logs endpoints apply the named policy, mirroring existing project conventions for endpoint helpers.

## Implementation Notes
- The change keeps behaviour identical while ensuring override consistency; no other files consume the parameter by name, so only the local signature and call site required updates.
- Added XML documentation to make the intent of the override explicit, aligning with the project guidance on descriptive comments for public endpoints.

## Testing
- dotnet test FlowSynx.sln *(not run: .NET SDK is unavailable in the current environment)*

Closes #610.