### PR TITLE
Feature: integrate Infisical configuration provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,33 @@ dotnet test
 
 For advanced workflows (Docker, local environment setup, contributing guidelines), see [CONTRIBUTING.md](https://github.com/flowsynx/flowsynx/blob/master/CONTRIBUTING.md).
 
+## Configuration Sources
+
+FlowSynx now supports selecting its configuration provider at startup. By default it reads from the bundled `appsettings*.json` files, but you can switch to [Infisical](https://infisical.com/) without recompiling the application.
+
+- **Environment variable:** set `FLOWSYNX_CONFIG_SOURCE=Infisical`.
+- **Command-line argument:** pass `--config-source=Infisical` (or `--config-source Infisical`).
+- **Fallback:** if Infisical is unreachable and fallback is enabled, FlowSynx logs a warning and reverts to the JSON files so the service can still boot.
+
+Configure the Infisical connection via the `Infisical` section (or matching environment variables):
+
+```json
+"Infisical": {
+  "Enabled": true,
+  "HostUri": "https://app.infisical.com",
+  "ProjectId": "<project-id>",
+  "EnvironmentSlug": "<environment-slug>",
+  "SecretPath": "/",
+  "FallbackToAppSettings": true,
+  "MachineIdentity": {
+    "ClientId": "<machine-identity-client-id>",
+    "ClientSecret": "<machine-identity-client-secret>"
+  }
+}
+```
+
+Refer to [docs/infisical-configuration.md](./docs/infisical-configuration.md) for end-to-end setup guidance, including secret naming conventions and recommended access policies.
+
 ## Architecture Overview
 
 <img src="/img/architecture-diagram.jpg" alt="FlowSynx Architecture Diagram"/>

--- a/docs/infisical-configuration.md
+++ b/docs/infisical-configuration.md
@@ -1,0 +1,70 @@
+# Infisical Configuration Guide
+
+FlowSynx can load its configuration from [Infisical](https://infisical.com/) in addition to the standard `appsettings*.json` files. This guide walks through the requirements, secret conventions, and runtime controls for switching between providers.
+
+## Prerequisites
+
+1. **Infisical project & environment**  
+   Collect the project ID and environment slug that holds your secrets.
+2. **Machine identity credentials**  
+   Create a machine identity in Infisical and copy its client ID and client secret. The identity should be scoped to the minimal set of secrets FlowSynx needs.
+3. **Secret naming**  
+   Store each configuration entry as a secret. Use either colon-delimited keys (`Logger:Level`) or double underscores (`Logger__Level`) to map into the hierarchical configuration system.
+
+## Configure FlowSynx
+
+Populate the `Infisical` section (either via `appsettings.json`, user secrets, or environment variables) with your connection metadata:
+
+```json
+"Infisical": {
+  "Enabled": true,
+  "ProjectId": "<project-id>",
+  "EnvironmentSlug": "<environment-slug>",
+  "SecretPath": "/",
+  "HostUri": "https://app.infisical.com",
+  "FallbackToAppSettings": true,
+  "MachineIdentity": {
+    "ClientId": "<machine-identity-client-id>",
+    "ClientSecret": "<machine-identity-client-secret>"
+  }
+}
+```
+
+Environment variables map using double underscores. For example:
+
+```bash
+export Infisical__MachineIdentity__ClientId="..."
+export Infisical__MachineIdentity__ClientSecret="..."
+```
+
+> ℹ️ Set `FallbackToAppSettings` to `false` to fail startup instead of silently reverting to JSON when Infisical is unavailable.
+
+## Choose the Configuration Source
+
+FlowSynx selects the configuration source at runtime without recompilation:
+
+- **Command line:** `dotnet run -- --start --config-source=Infisical`
+- **Environment variable:** `export FLOWSYNX_CONFIG_SOURCE=Infisical`
+- **appsettings:** set `Configuration:Source` to `Infisical` as a default (can still be overridden).
+
+If Infisical is requested but disabled (`Enabled: false`), FlowSynx remains on the JSON files.
+
+## Observability & Logging
+
+During startup FlowSynx logs the active configuration source:
+
+```
+info: Configuration source in use: Infisical
+```
+
+When fallback is enabled and Infisical cannot be reached, the application logs a warning and continues:
+
+```
+warn: Infisical configuration was requested but appsettings.json was used as a fallback.
+```
+
+No secret values are logged—only the provider state—helping you confirm behaviour without exposing sensitive information.
+
+## Secret Refresh
+
+The first iteration of the integration loads secrets at startup. Restart FlowSynx to consume updates or add secret hot-reload logic in a future enhancement.

--- a/src/FlowSynx.Application/Configuration/ConfigurationSourceOption.cs
+++ b/src/FlowSynx.Application/Configuration/ConfigurationSourceOption.cs
@@ -1,0 +1,17 @@
+namespace FlowSynx.Application.Configuration;
+
+/// <summary>
+/// Enumerates the available configuration providers recognised by FlowSynx.
+/// </summary>
+public enum ConfigurationSourceOption
+{
+    /// <summary>
+    /// Use the local appsettings files as the primary configuration provider.
+    /// </summary>
+    AppSettings = 0,
+
+    /// <summary>
+    /// Load configuration values from Infisical.
+    /// </summary>
+    Infisical = 1
+}

--- a/src/FlowSynx.Application/Configuration/InfisicalConfiguration.cs
+++ b/src/FlowSynx.Application/Configuration/InfisicalConfiguration.cs
@@ -1,0 +1,58 @@
+namespace FlowSynx.Application.Configuration;
+
+/// <summary>
+/// Represents configuration settings required to fetch secrets from Infisical.
+/// </summary>
+public sealed class InfisicalConfiguration
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether Infisical integration is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the Infisical host URI. Defaults to the public cloud endpoint when not specified.
+    /// </summary>
+    public string? HostUri { get; set; }
+
+    /// <summary>
+    /// Gets or sets the Infisical project identifier that contains configuration secrets.
+    /// </summary>
+    public string ProjectId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the environment slug that maps to the desired Infisical environment.
+    /// </summary>
+    public string EnvironmentSlug { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the secret path within the Infisical project. Defaults to the root path.
+    /// </summary>
+    public string SecretPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether FlowSynx should fall back to appsettings when Infisical access fails.
+    /// </summary>
+    public bool FallbackToAppSettings { get; set; } = true;
+
+    /// <summary>
+    /// Gets the machine identity credentials used to authenticate against Infisical.
+    /// </summary>
+    public InfisicalMachineIdentityConfiguration MachineIdentity { get; set; } = new();
+}
+
+/// <summary>
+/// Represents the machine identity credentials used to authenticate against Infisical.
+/// </summary>
+public sealed class InfisicalMachineIdentityConfiguration
+{
+    /// <summary>
+    /// Gets or sets the Infisical machine identity client identifier.
+    /// </summary>
+    public string ClientId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Infisical machine identity client secret.
+    /// </summary>
+    public string ClientSecret { get; set; } = string.Empty;
+}

--- a/src/FlowSynx.Infrastructure/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/FlowSynx.Infrastructure/Configuration/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using FlowSynx.Application.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace FlowSynx.Infrastructure.Configuration;
+
+/// <summary>
+/// Extension methods for registering Infisical as a configuration source.
+/// </summary>
+public static class ConfigurationBuilderExtensions
+{
+    /// <summary>
+    /// Adds Infisical as a configuration source to the provided configuration builder.
+    /// </summary>
+    /// <param name="configurationBuilder">The configuration builder.</param>
+    /// <param name="options">Infisical configuration options.</param>
+    /// <param name="loggerFactory">Optional logger factory for diagnostics.</param>
+    /// <param name="clientFactory">Optional custom client factory (useful for testing).</param>
+    /// <returns>The configuration builder for chaining.</returns>
+    public static IConfigurationBuilder AddInfisical(
+        this IConfigurationBuilder configurationBuilder,
+        InfisicalConfiguration options,
+        ILoggerFactory? loggerFactory = null,
+        Func<InfisicalConfiguration, ILoggerFactory?, IInfisicalSecretClient>? clientFactory = null)
+    {
+        if (configurationBuilder is null)
+            throw new ArgumentNullException(nameof(configurationBuilder));
+
+        if (options is null)
+            throw new ArgumentNullException(nameof(options));
+
+        configurationBuilder.Add(new InfisicalConfigurationSource(options, clientFactory, loggerFactory));
+        return configurationBuilder;
+    }
+}

--- a/src/FlowSynx.Infrastructure/Configuration/ConfigurationSourceSelector.cs
+++ b/src/FlowSynx.Infrastructure/Configuration/ConfigurationSourceSelector.cs
@@ -1,0 +1,96 @@
+using System;
+using FlowSynx.Application.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace FlowSynx.Infrastructure.Configuration;
+
+/// <summary>
+/// Resolves the configuration source that FlowSynx should use at runtime.
+/// </summary>
+public static class ConfigurationSourceSelector
+{
+    /// <summary>
+    /// Environment variable key used to determine the configuration source.
+    /// </summary>
+    public const string EnvironmentVariableKey = "FLOWSYNX_CONFIG_SOURCE";
+
+    /// <summary>
+    /// Configuration key that stores the requested source.
+    /// </summary>
+    public const string ConfigurationSectionKey = "Configuration:Source";
+
+    /// <summary>
+    /// Configuration key that stores the active source used after resolution.
+    /// </summary>
+    public const string ActiveSourceConfigurationKey = "Configuration:ActiveSource";
+
+    /// <summary>
+    /// Configuration key that flags a fallback to appsettings due to Infisical failure.
+    /// </summary>
+    public const string InfisicalFallbackKey = "Configuration:InfisicalFallback";
+
+    /// <summary>
+    /// Resolves the configuration source to use, favouring command-line arguments, then environment variables, then appsettings.
+    /// </summary>
+    /// <param name="args">Application command-line arguments.</param>
+    /// <param name="configuration">Current configuration manager.</param>
+    /// <returns>The resolved configuration source option.</returns>
+    public static ConfigurationSourceOption Resolve(string[] args, IConfiguration configuration)
+    {
+        if (configuration is null)
+            throw new ArgumentNullException(nameof(configuration));
+
+        var resolvedFromArgs = ParseFromArguments(args);
+        if (resolvedFromArgs.HasValue)
+            return resolvedFromArgs.Value;
+
+        var resolvedFromEnvironment = ParseOption(Environment.GetEnvironmentVariable(EnvironmentVariableKey));
+        if (resolvedFromEnvironment.HasValue)
+            return resolvedFromEnvironment.Value;
+
+        var resolvedFromConfiguration = ParseOption(configuration[ConfigurationSectionKey]);
+        if (resolvedFromConfiguration.HasValue)
+            return resolvedFromConfiguration.Value;
+
+        return ConfigurationSourceOption.AppSettings;
+    }
+
+    private static ConfigurationSourceOption? ParseFromArguments(string[] args)
+    {
+        if (args is null || args.Length == 0)
+            return null;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (argument.StartsWith("--config-source=", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = argument[(argument.IndexOf('=') + 1)..];
+                return ParseOption(value);
+            }
+
+            if (!string.Equals(argument, "--config-source", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            if (index + 1 >= args.Length)
+                break;
+
+            return ParseOption(args[index + 1]);
+        }
+
+        return null;
+    }
+
+    private static ConfigurationSourceOption? ParseOption(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        if (Enum.TryParse<ConfigurationSourceOption>(value, ignoreCase: true, out var parsed))
+            return parsed;
+
+        return value.Trim().Equals("json", StringComparison.OrdinalIgnoreCase)
+            ? ConfigurationSourceOption.AppSettings
+            : null;
+    }
+}

--- a/src/FlowSynx.Infrastructure/Configuration/IInfisicalSecretClient.cs
+++ b/src/FlowSynx.Infrastructure/Configuration/IInfisicalSecretClient.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FlowSynx.Infrastructure.Configuration;
+
+/// <summary>
+/// Contract for fetching configuration secrets from Infisical.
+/// </summary>
+public interface IInfisicalSecretClient
+{
+    /// <summary>
+    /// Retrieves the secret collection with keys mapped to configuration paths.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token propagated to the underlying SDK.</param>
+    /// <returns>A read-only collection of configuration key/value pairs.</returns>
+    Task<IReadOnlyCollection<KeyValuePair<string, string>>> GetSecretsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/FlowSynx.Infrastructure/Configuration/InfisicalConfigurationException.cs
+++ b/src/FlowSynx.Infrastructure/Configuration/InfisicalConfigurationException.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace FlowSynx.Infrastructure.Configuration;
+
+/// <summary>
+/// Represents errors that occur while loading Infisical configuration.
+/// </summary>
+public sealed class InfisicalConfigurationException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InfisicalConfigurationException"/> class.
+    /// </summary>
+    public InfisicalConfigurationException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InfisicalConfigurationException"/> class with a specified error message.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    public InfisicalConfigurationException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InfisicalConfigurationException"/> class.
+    /// </summary>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">The exception that caused the current exception.</param>
+    public InfisicalConfigurationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/FlowSynx.Infrastructure/Configuration/InfisicalConfigurationProvider.cs
+++ b/src/FlowSynx.Infrastructure/Configuration/InfisicalConfigurationProvider.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace FlowSynx.Infrastructure.Configuration;
+
+/// <summary>
+/// Configuration provider that maps Infisical secrets to the ASP.NET configuration pipeline.
+/// </summary>
+public sealed class InfisicalConfigurationProvider : ConfigurationProvider
+{
+    private readonly IInfisicalSecretClient _secretClient;
+    private readonly ILogger<InfisicalConfigurationProvider>? _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InfisicalConfigurationProvider"/> class.
+    /// </summary>
+    /// <param name="secretClient">Client responsible for retrieving Infisical secrets.</param>
+    /// <param name="logger">Optional logger used for diagnostics.</param>
+    public InfisicalConfigurationProvider(
+        IInfisicalSecretClient secretClient,
+        ILogger<InfisicalConfigurationProvider>? logger = null)
+    {
+        _secretClient = secretClient ?? throw new ArgumentNullException(nameof(secretClient));
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public override void Load()
+    {
+        try
+        {
+            var secrets = _secretClient
+                .GetSecretsAsync()
+                .GetAwaiter()
+                .GetResult();
+
+            Data = secrets.Count == 0
+                ? new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
+                : new Dictionary<string, string?>(secrets.Count, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var secret in secrets)
+            {
+                Data[secret.Key] = secret.Value;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Failed to load configuration from Infisical.");
+            throw new InfisicalConfigurationException("Failed to load configuration from Infisical.", ex);
+        }
+    }
+}

--- a/src/FlowSynx.Infrastructure/Configuration/InfisicalConfigurationSource.cs
+++ b/src/FlowSynx.Infrastructure/Configuration/InfisicalConfigurationSource.cs
@@ -1,0 +1,48 @@
+using System;
+using FlowSynx.Application.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace FlowSynx.Infrastructure.Configuration;
+
+/// <summary>
+/// Provides the configuration source definition used to register the Infisical configuration provider.
+/// </summary>
+public sealed class InfisicalConfigurationSource : IConfigurationSource
+{
+    private readonly InfisicalConfiguration _options;
+    private readonly ILoggerFactory? _loggerFactory;
+    private readonly Func<InfisicalConfiguration, ILoggerFactory?, IInfisicalSecretClient> _clientFactory;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InfisicalConfigurationSource"/> class.
+    /// </summary>
+    /// <param name="options">The Infisical configuration options.</param>
+    /// <param name="clientFactory">Factory that constructs an Infisical secret client.</param>
+    /// <param name="loggerFactory">Optional logger factory used to create provider loggers.</param>
+    public InfisicalConfigurationSource(
+        InfisicalConfiguration options,
+        Func<InfisicalConfiguration, ILoggerFactory?, IInfisicalSecretClient>? clientFactory = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _loggerFactory = loggerFactory;
+        _clientFactory = clientFactory ?? DefaultClientFactory;
+    }
+
+    /// <inheritdoc />
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        var client = _clientFactory(_options, _loggerFactory);
+        var providerLogger = _loggerFactory?.CreateLogger<InfisicalConfigurationProvider>();
+        return new InfisicalConfigurationProvider(client, providerLogger);
+    }
+
+    private static IInfisicalSecretClient DefaultClientFactory(
+        InfisicalConfiguration configuration,
+        ILoggerFactory? loggerFactory)
+    {
+        var logger = loggerFactory?.CreateLogger<InfisicalSecretClient>();
+        return new InfisicalSecretClient(configuration, logger);
+    }
+}

--- a/src/FlowSynx.Infrastructure/Configuration/InfisicalSecretClient.cs
+++ b/src/FlowSynx.Infrastructure/Configuration/InfisicalSecretClient.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FlowSynx.Application.Configuration;
+using Infisical.Sdk;
+using Infisical.Sdk.Model;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace FlowSynx.Infrastructure.Configuration;
+
+/// <summary>
+/// Fetches configuration secrets from Infisical using the official SDK.
+/// </summary>
+public sealed class InfisicalSecretClient : IInfisicalSecretClient
+{
+    private readonly InfisicalConfiguration _options;
+    private readonly ILogger<InfisicalSecretClient>? _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InfisicalSecretClient"/> class.
+    /// </summary>
+    /// <param name="options">The Infisical configuration options.</param>
+    /// <param name="logger">Optional logger used for diagnostic messages.</param>
+    public InfisicalSecretClient(InfisicalConfiguration options, ILogger<InfisicalSecretClient>? logger = null)
+    {
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<KeyValuePair<string, string>>> GetSecretsAsync(CancellationToken cancellationToken = default)
+    {
+        ValidateRequiredOptions();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var settingsBuilder = new InfisicalSdkSettingsBuilder();
+        if (!string.IsNullOrWhiteSpace(_options.HostUri))
+        {
+            if (!Uri.TryCreate(_options.HostUri, UriKind.Absolute, out var hostUri))
+            {
+                throw new InvalidOperationException($"Invalid Infisical host URI '{_options.HostUri}'.");
+            }
+
+            settingsBuilder.WithHostUri(hostUri.ToString());
+        }
+
+        var infisicalClient = new InfisicalClient(settingsBuilder.Build());
+
+        try
+        {
+            await infisicalClient
+                .Auth()
+                .UniversalAuth()
+                .LoginAsync(_options.MachineIdentity.ClientId, _options.MachineIdentity.ClientSecret)
+                .ConfigureAwait(false);
+
+            var secrets = await infisicalClient
+                .Secrets()
+                .ListAsync(BuildListSecretOptions())
+                .ConfigureAwait(false);
+
+            if (secrets is null || secrets.Length == 0)
+                return Array.Empty<KeyValuePair<string, string>>();
+
+            var result = new List<KeyValuePair<string, string>>(secrets.Length);
+            foreach (var secret in secrets)
+            {
+                if (string.IsNullOrWhiteSpace(secret.SecretKey))
+                    continue;
+
+                var normalizedKey = NormalizeKey(secret.SecretKey);
+                if (string.IsNullOrEmpty(normalizedKey))
+                    continue;
+
+                if (secret.SecretValue is null)
+                    continue;
+
+                result.Add(new KeyValuePair<string, string>(normalizedKey, secret.SecretValue));
+            }
+
+            return result;
+        }
+        catch (Exception ex) when (ex is not InvalidOperationException)
+        {
+            _logger?.LogWarning(ex, "Unexpected error while retrieving configuration secrets from Infisical.");
+            throw;
+        }
+    }
+
+    private void ValidateRequiredOptions()
+    {
+        if (string.IsNullOrWhiteSpace(_options.ProjectId))
+            throw new InvalidOperationException("Infisical ProjectId is required when using Infisical as a configuration source.");
+
+        if (string.IsNullOrWhiteSpace(_options.EnvironmentSlug))
+            throw new InvalidOperationException("Infisical EnvironmentSlug is required when using Infisical as a configuration source.");
+
+        if (string.IsNullOrWhiteSpace(_options.MachineIdentity.ClientId))
+            throw new InvalidOperationException("Infisical MachineIdentity.ClientId is required when using Infisical as a configuration source.");
+
+        if (string.IsNullOrWhiteSpace(_options.MachineIdentity.ClientSecret))
+            throw new InvalidOperationException("Infisical MachineIdentity.ClientSecret is required when using Infisical as a configuration source.");
+    }
+
+    private ListSecretsOptions BuildListSecretOptions()
+    {
+        return new ListSecretsOptions
+        {
+            EnvironmentSlug = _options.EnvironmentSlug,
+            ProjectId = _options.ProjectId,
+            SecretPath = string.IsNullOrWhiteSpace(_options.SecretPath) ? "/" : _options.SecretPath,
+            ExpandSecretReferences = true,
+            SetSecretsAsEnvironmentVariables = false
+        };
+    }
+
+    private static string NormalizeKey(string secretKey)
+    {
+        var trimmedKey = secretKey.Trim();
+
+        if (trimmedKey.Length == 0)
+            return string.Empty;
+
+        // Support both colon and double underscore delimiters.
+        var normalized = trimmedKey.Replace("__", ConfigurationPath.KeyDelimiter, StringComparison.Ordinal);
+        return normalized.Replace(" ", string.Empty, StringComparison.Ordinal);
+    }
+}

--- a/src/FlowSynx.Infrastructure/FlowSynx.Infrastructure.csproj
+++ b/src/FlowSynx.Infrastructure/FlowSynx.Infrastructure.csproj
@@ -16,6 +16,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
+		<PackageReference Include="Infisical.Sdk" Version="3.0.3" />
 		<PackageReference Include="NJsonSchema" Version="10.9.0" />
 	</ItemGroup>
 

--- a/src/FlowSynx/Program.cs
+++ b/src/FlowSynx/Program.cs
@@ -1,11 +1,14 @@
+using FlowSynx.Application.Configuration;
 using FlowSynx.Application.Extensions;
 using FlowSynx.Extensions;
 using FlowSynx.Hubs;
 using FlowSynx.Infrastructure.Extensions;
+using FlowSynx.Infrastructure.Configuration;
 using FlowSynx.Infrastructure.Workflow.Triggers.HttpBased;
 using FlowSynx.Persistence.Postgres.Extensions;
 using FlowSynx.Persistence.SQLite.Extensions;
 using FlowSynx.Services;
+using Microsoft.Extensions.Logging;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -27,6 +30,38 @@ try
         builder.Configuration.Sources.Clear(); // Optional: clear defaults
         builder.Configuration.AddJsonFile(customConfigPath, optional: false, reloadOnChange: false);
     }
+
+    var requestedConfigurationSource = ConfigurationSourceSelector.Resolve(args, builder.Configuration);
+    var activeConfigurationSource = requestedConfigurationSource;
+    var infisicalFallbackUsed = false;
+
+    if (requestedConfigurationSource == ConfigurationSourceOption.Infisical)
+    {
+        var infisicalConfiguration = new InfisicalConfiguration();
+        builder.Configuration.GetSection("Infisical").Bind(infisicalConfiguration);
+
+        if (!infisicalConfiguration.Enabled)
+        {
+            activeConfigurationSource = ConfigurationSourceOption.AppSettings;
+        }
+        else
+        {
+            try
+            {
+                builder.Configuration.AddInfisical(infisicalConfiguration);
+            }
+            catch (Exception ex) when (infisicalConfiguration.FallbackToAppSettings)
+            {
+                activeConfigurationSource = ConfigurationSourceOption.AppSettings;
+                infisicalFallbackUsed = true;
+                Console.Error.WriteLine("Warning: Failed to load configuration from Infisical. Falling back to appsettings.json.");
+                Console.Error.WriteLine($"Reason: {ex.GetType().Name}");
+            }
+        }
+    }
+
+    builder.Configuration[ConfigurationSourceSelector.ActiveSourceConfigurationKey] = activeConfigurationSource.ToString();
+    builder.Configuration[ConfigurationSourceSelector.InfisicalFallbackKey] = infisicalFallbackUsed.ToString();
 
     IConfiguration config = builder.Configuration;
 
@@ -68,6 +103,16 @@ try
     builder.Services.AddConfiguredCors(config);
 
     var app = builder.Build();
+
+    var startupLogger = app.Services.GetRequiredService<ILogger<Program>>();
+    var activeSource = app.Configuration[ConfigurationSourceSelector.ActiveSourceConfigurationKey]
+                       ?? ConfigurationSourceOption.AppSettings.ToString();
+    startupLogger.LogInformation("Configuration source in use: {Source}", activeSource);
+
+    if (bool.TryParse(app.Configuration[ConfigurationSourceSelector.InfisicalFallbackKey], out var fallback) && fallback)
+    {
+        startupLogger.LogWarning("Infisical configuration was requested but appsettings.json was used as a fallback.");
+    }
 
     if (app.Environment.IsDevelopment())
     {

--- a/src/FlowSynx/appsettings.Development.json
+++ b/src/FlowSynx/appsettings.Development.json
@@ -1,4 +1,19 @@
 {
+  "Configuration": {
+    "Source": "AppSettings"
+  },
+  "Infisical": {
+    "Enabled": false,
+    "HostUri": "",
+    "ProjectId": "",
+    "EnvironmentSlug": "",
+    "SecretPath": "/",
+    "FallbackToAppSettings": true,
+    "MachineIdentity": {
+      "ClientId": "",
+      "ClientSecret": ""
+    }
+  },
   "Db": {
     "Host": "localhost",
     "Port": 5432,

--- a/src/FlowSynx/appsettings.json
+++ b/src/FlowSynx/appsettings.json
@@ -7,6 +7,21 @@
   "Logger": {
     "Level": "Info"
   },
+  "Configuration": {
+    "Source": "AppSettings"
+  },
+  "Infisical": {
+    "Enabled": false,
+    "HostUri": "",
+    "ProjectId": "",
+    "EnvironmentSlug": "",
+    "SecretPath": "/",
+    "FallbackToAppSettings": true,
+    "MachineIdentity": {
+      "ClientId": "",
+      "ClientSecret": ""
+    }
+  },
   "HealthCheck": {
     "Enabled": false
   },

--- a/tests/FlowSynx.UnitTests/Configuration/ConfigurationSourceSelectorTests.cs
+++ b/tests/FlowSynx.UnitTests/Configuration/ConfigurationSourceSelectorTests.cs
@@ -1,0 +1,51 @@
+using System;
+using FlowSynx.Application.Configuration;
+using FlowSynx.Infrastructure.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace FlowSynx.UnitTests.Configuration;
+
+public class ConfigurationSourceSelectorTests
+{
+    [Fact]
+    public void Resolve_UsesCommandLineArgumentWhenPresent()
+    {
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+
+        var option = ConfigurationSourceSelector.Resolve(
+            new[] { "--config-source=Infisical" },
+            configuration);
+
+        Assert.Equal(ConfigurationSourceOption.Infisical, option);
+    }
+
+    [Fact]
+    public void Resolve_UsesEnvironmentVariableAsFallback()
+    {
+        var configuration = new ConfigurationBuilder().Build();
+        var originalValue = Environment.GetEnvironmentVariable(ConfigurationSourceSelector.EnvironmentVariableKey);
+
+        try
+        {
+            Environment.SetEnvironmentVariable(ConfigurationSourceSelector.EnvironmentVariableKey, "Infisical");
+
+            var option = ConfigurationSourceSelector.Resolve(Array.Empty<string>(), configuration);
+
+            Assert.Equal(ConfigurationSourceOption.Infisical, option);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(ConfigurationSourceSelector.EnvironmentVariableKey, originalValue);
+        }
+    }
+
+    [Fact]
+    public void Resolve_DefaultsToAppSettingsWhenNoOverrides()
+    {
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+
+        var option = ConfigurationSourceSelector.Resolve(Array.Empty<string>(), configuration);
+
+        Assert.Equal(ConfigurationSourceOption.AppSettings, option);
+    }
+}

--- a/tests/FlowSynx.UnitTests/Configuration/InfisicalConfigurationProviderTests.cs
+++ b/tests/FlowSynx.UnitTests/Configuration/InfisicalConfigurationProviderTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FlowSynx.Infrastructure.Configuration;
+
+namespace FlowSynx.UnitTests.Configuration;
+
+public class InfisicalConfigurationProviderTests
+{
+    [Fact]
+    public void Load_PopulatesConfigurationDataFromClient()
+    {
+        var secrets = new[]
+        {
+            new KeyValuePair<string, string>("Logger:Level", "Debug"),
+            new KeyValuePair<string, string>("Security:DefaultScheme", "Jwt")
+        };
+
+        var provider = new InfisicalConfigurationProvider(new InMemorySecretClient(secrets));
+
+        provider.Load();
+
+        Assert.True(provider.TryGet("Logger:Level", out var loggerLevel));
+        Assert.Equal("Debug", loggerLevel);
+
+        Assert.True(provider.TryGet("Security:DefaultScheme", out var defaultScheme));
+        Assert.Equal("Jwt", defaultScheme);
+    }
+
+    [Fact]
+    public void Load_ThrowsInfisicalConfigurationExceptionWhenClientFails()
+    {
+        var provider = new InfisicalConfigurationProvider(new ThrowingSecretClient());
+
+        Assert.Throws<InfisicalConfigurationException>(provider.Load);
+    }
+
+    private sealed class InMemorySecretClient : IInfisicalSecretClient
+    {
+        private readonly IReadOnlyCollection<KeyValuePair<string, string>> _secrets;
+
+        public InMemorySecretClient(IReadOnlyCollection<KeyValuePair<string, string>> secrets)
+        {
+            _secrets = secrets;
+        }
+
+        public Task<IReadOnlyCollection<KeyValuePair<string, string>>> GetSecretsAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_secrets);
+        }
+    }
+
+    private sealed class ThrowingSecretClient : IInfisicalSecretClient
+    {
+        public Task<IReadOnlyCollection<KeyValuePair<string, string>>> GetSecretsAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new InvalidOperationException("boom");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add an Infisical-backed configuration provider with runtime source selection
- expose CLI/env toggles, fallback handling, and startup logging for active source
- document Infisical setup and cover selectors with unit tests

## Testing
- dotnet test

Closes #558