### PR TITLE
fix: align Metrics Map signature with rate limit naming

### DIFF
--- a/src/FlowSynx/Endpoints/Metrics.cs
+++ b/src/FlowSynx/Endpoints/Metrics.cs
@@ -7,10 +7,15 @@ namespace FlowSynx.Endpoints;
 
 public class Metrics : EndpointGroupBase
 {
-    public override void Map(WebApplication app, string rateLimitPolicy)
+    /// <summary>
+    /// Register the metrics endpoints and apply the configured rate-limiting policy.
+    /// </summary>
+    /// <param name="app">Application builder used to define endpoints.</param>
+    /// <param name="rateLimitPolicyName">Named rate-limiting policy applied to this group.</param>
+    public override void Map(WebApplication app, string rateLimitPolicyName)
     {
         var group = app.MapGroup(this)
-                       .RequireRateLimiting(rateLimitPolicy);
+                       .RequireRateLimiting(rateLimitPolicyName);
 
         group.MapGet("", GetWorkflowSummary)
             .WithName("GetWorkflowSummary")


### PR DESCRIPTION
## Summary
- rename Metrics.Map parameter to ateLimitPolicyName to match EndpointGroupBase
- ensure the metrics endpoint group applies rate limiting using the renamed parameter
- add XML documentation that clarifies the rate-limiting parameter for the metrics endpoints

## Testing
- dotnet test *(fails: dotnet CLI is not available in this environment)*

Closes #609