### PR TITLE
Align Config endpoint Map signature with base class

### DIFF
--- a/src/FlowSynx/Endpoints/Config.cs
+++ b/src/FlowSynx/Endpoints/Config.cs
@@ -10,10 +10,15 @@ namespace FlowSynx.Endpoints;
 
 public class Config : EndpointGroupBase
 {
-    public override void Map(WebApplication app, string rateLimitPolicy)
+    /// <summary>
+    /// Register the configuration endpoints and apply the configured rate-limiting policy.
+    /// </summary>
+    /// <param name="app">Application builder used to define endpoints.</param>
+    /// <param name="rateLimitPolicyName">Named rate-limiting policy applied to this group.</param>
+    public override void Map(WebApplication app, string rateLimitPolicyName)
     {
         var group = app.MapGroup(this)
-                       .RequireRateLimiting(rateLimitPolicy);
+                       .RequireRateLimiting(rateLimitPolicyName);
 
         group.MapGet("", PluginsConfiguration)
             .WithName("PluginsConfiguration")


### PR DESCRIPTION
## Summary
- Rename the Config endpoint's Map parameter to 
ateLimitPolicyName to mirror EndpointGroupBase
- Update the rate limiting registration to use the renamed parameter
- Document the endpoint registration to match the conventions used by other endpoint groups

## Testing
- Not run: dotnet test *(dotnet CLI is not installed in the current environment)*

Fixes #611