### PR TITLE
Rename Audits rate limit parameter

### DIFF
--- a/src/FlowSynx/Endpoints/Audits.cs
+++ b/src/FlowSynx/Endpoints/Audits.cs
@@ -8,10 +8,10 @@ namespace FlowSynx.Endpoints;
 
 public class Audits : EndpointGroupBase
 {
-    public override void Map(WebApplication app, string rateLimitPolicy)
+    public override void Map(WebApplication app, string rateLimitPolicyName)
     {
         var group = app.MapGroup(this)
-                       .RequireRateLimiting(rateLimitPolicy);
+                       .RequireRateLimiting(rateLimitPolicyName);
 
         group.MapGet("", AuditsList)
             .WithName("AuditsList")


### PR DESCRIPTION
## Summary
- Align the Audits.Map signature with EndpointGroupBase by renaming the rate limit argument to 
ateLimitPolicyName for consistency
- Propagate the renamed parameter inside the method so the configured rate-limiting policy remains in sync with the new signature

## Testing
- Dotnet test *(fails: dotnet CLI not available in this environment)*

Closes #612