### PR TITLE
Make _options field readonly in InfisicalSecretProvider

### DIFF
--- a/src/FlowSynx.Infrastructure/Secrets/Infisical/InfisicalSecretProvider.cs
+++ b/src/FlowSynx.Infrastructure/Secrets/Infisical/InfisicalSecretProvider.cs
@@ -9,7 +9,7 @@ namespace FlowSynx.Infrastructure.Secrets.Infisical;
 public class InfisicalSecretProvider : ISecretProvider, IConfigurableSecret
 {
     private readonly ILogger<InfisicalSecretProvider>? _logger;
-    private InfisicalConfiguration _options = new InfisicalConfiguration();
+    private readonly InfisicalConfiguration _options = new InfisicalConfiguration();
 
     public InfisicalSecretProvider(
         ILogger<InfisicalSecretProvider>? logger = null)


### PR DESCRIPTION
## Summary
- Marks the `_options` field as `readonly` in `InfisicalSecretProvider` class to enforce immutability
- Improves code safety and thread safety without changing any runtime behavior

## Rationale
The `_options` field is initialized once and never reassigned. Making it `readonly` prevents accidental reassignment while still allowing property modifications through the `Configure` method. This aligns with C# best practices for immutable references.

## Changes
- Modified `src/FlowSynx.Infrastructure/Secrets/Infisical/InfisicalSecretProvider.cs` line 12
- Added `readonly` modifier to `_options` field declaration

## Testing
- This change does not modify any logic or runtime behavior
- The `readonly` modifier only prevents field reassignment, not property modification
- CI/CD tests will verify no regressions were introduced

Fixes #628