### PR TITLE
Simplify AddRolesFromClaim to project claim values

### DIFF
--- a/src/FlowSynx/Security/RoleClaimsTransformation.cs
+++ b/src/FlowSynx/Security/RoleClaimsTransformation.cs
@@ -1,6 +1,7 @@
 using FlowSynx.Application.Configuration;
 using Microsoft.AspNetCore.Authentication;
 using System;
+using System.Linq;
 using System.Security.Claims;
 using System.Text.Json;
 
@@ -61,19 +62,16 @@ public class RoleClaimsTransformation : IClaimsTransformation
     /// <param name="roles">Role accumulator that guards against duplicates.</param>
     private static void AddRolesFromClaim(ClaimsIdentity identity, string claimType, HashSet<string> roles)
     {
-        foreach (var claim in identity.FindAll(claimType))
+        foreach (var value in identity.FindAll(claimType)
+                                      .Select(claim => claim.Value)
+                                      .Where(claimValue => !string.IsNullOrWhiteSpace(claimValue)))
         {
-            if (string.IsNullOrWhiteSpace(claim.Value))
+            if (TryAddJsonArrayRoles(value, roles))
             {
                 continue;
             }
 
-            if (TryAddJsonArrayRoles(claim.Value, roles))
-            {
-                continue;
-            }
-
-            AddDelimitedOrSingleRole(claim.Value, roles);
+            AddDelimitedOrSingleRole(value, roles);
         }
     }
 


### PR DESCRIPTION
## Summary
- closes #630 by refactoring AddRolesFromClaim to project claim payloads with LINQ before processing
- keeps existing guardrails for JSON arrays and delimited roles so downstream behavior remains stable

## Implementation Details
- add System.Linq import and pivot the claim loop to Select claim values while filtering empty payloads before processing
- retain short-circuiting on TryAddJsonArrayRoles and reuse the existing delimiter handling to match current conventions
- mirror the surrounding formatting and doc comment structure to stay consistent with FlowSynx coding standards

## Testing
- dotnet test *(not run: dotnet CLI is unavailable in this environment)*