### PR TITLE
Fix: align AbortStrategy cancellation token parameter name

### DIFF
--- a/src/FlowSynx.Infrastructure/Workflow/ErrorHandlingStrategies/AbortStrategy.cs
+++ b/src/FlowSynx.Infrastructure/Workflow/ErrorHandlingStrategies/AbortStrategy.cs
@@ -15,7 +15,7 @@ public class AbortStrategy: IErrorHandlingStrategy
 
     public Task<ErrorHandlingResult> HandleAsync(
         ErrorHandlingContext context, 
-        CancellationToken cancellation)
+        CancellationToken cancellationToken)
     {
         _logger.LogInformation(Localization.Get("Workflow_AbortStrategy_Handle", context.TaskName));
         return Task.FromResult(new ErrorHandlingResult { ShouldAbortWorkflow = true });


### PR DESCRIPTION
## Summary
- Rename the cancellation parameter in IErrorHandlingStrategy to cancellationToken, matching the interface declaration across the workflow error handling strategies
- Update AbortStrategy to accept a CancellationToken named cancellationToken for clarity and consistency with the shared contract and other strategies

## Testing
- Dotnet test *(fails: installed SDK 8.0.415 cannot target net9; a .NET 9 SDK is required)*

Closes #643