### PR TITLE
add default audit type behaviour for entity state when entity changes

### DIFF
--- a/src/FlowSynx.Persistence.Postgres/Contexts/AuditableContext.cs
+++ b/src/FlowSynx.Persistence.Postgres/Contexts/AuditableContext.cs
@@ -108,6 +108,10 @@ public abstract class AuditableContext(DbContextOptions options) : DbContext(opt
                     auditEntry.NewValues[propertyName] = property.CurrentValue!;
                 }
                 break;
+
+            default:
+                auditEntry.AuditType = AuditType.None;
+                break;
         }
     }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ x ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- Added a default case for handling unrecognized EntityState values when saving changes to the database and auditing

## Issue reference

- Closes https://github.com/flowsynx/flowsynx/issues/652

## Testing
 
- Currently no tests for Persistence.Postgres
