### PR TITLE
fix: remove outdated comment in ParseArguments method

### DIFF
--- a/src/FlowSynx/Extensions/ServiceCollectionExtensions.cs
+++ b/src/FlowSynx/Extensions/ServiceCollectionExtensions.cs
@@ -319,8 +319,7 @@ public static class ServiceCollectionExtensions
             var errorMessage = new ErrorMessage((int)ErrorCode.ApplicationStartArgumentIsRequired, "The '--start' argument is required.");
             logger.LogError(errorMessage.ToString());
 
-            // if the console closes immediately, the output may not be visible.
-            // So, added await Task.Delay(500) here;
+            // Brief delay to ensure the error message is visible before exiting
             Task.Delay(500).Wait();
 
             Environment.Exit(1);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR removes an outdated comment in the `ParseArguments` extension method within `ServiceCollectionExtensions.cs`.

The previous comment referred to an asynchronous delay that no longer exists, which could cause confusion.

## Issue reference
Closes #668 
