### PR TITLE
fix: use ArgumentException instead of Exception for code clarity

### DIFF
--- a/src/FlowSynx/Services/PluginsLocation.cs
+++ b/src/FlowSynx/Services/PluginsLocation.cs
@@ -22,7 +22,7 @@ public class PluginsLocation : IPluginsLocation
             return;
 
         logger.LogError("Base location not found");
-        throw new Exception(_localization.Get("FlowSynxLocationBaseLocationNotFound"));
+        throw new ArgumentException(_localization.Get("FlowSynxLocationBaseLocationNotFound"));
     }
 
     public string Path => GetPluginsPath();


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Now throwing `new ArgumentException` instead of `new Exception` in `PluginsLocation` for easier debugging, and code clarity.

## Issue reference
Closes #680 

