### PR TITLE
Simplify eviction callback handling

### DIFF
--- a/src/FlowSynx.Infrastructure/PluginHost/Cache/PluginCacheService.cs
+++ b/src/FlowSynx.Infrastructure/PluginHost/Cache/PluginCacheService.cs
@@ -82,16 +82,17 @@ public class PluginCacheService : IPluginCacheService
         }
     }
 
+    /// <summary>
+    /// Attaches a post-eviction callback so plugin handles are unloaded once the cache expires or is cleared.
+    /// </summary>
     private void RegisterEvictionCallback(MemoryCacheEntryOptions options)
     {
         options.RegisterPostEvictionCallback((_, evictedValue, reason, _) =>
         {
-            if (reason is EvictionReason.Expired or EvictionReason.Removed)
+            if ((reason is EvictionReason.Expired or EvictionReason.Removed) &&
+                evictedValue is IPluginLoader pluginHandle)
             {
-                if (evictedValue is IPluginLoader pluginHandle)
-                {
-                    pluginHandle.Unload();
-                }
+                pluginHandle.Unload();
             }
         });
     }


### PR DESCRIPTION
## Summary
- merge the redundant nested eviction checks in PluginCacheService so unload only runs when the cache entry both expired or was removed and is a plugin loader, matching existing patterns in the infrastructure layer
- add an XML summary on RegisterEvictionCallback to document why the callback exists and keep inline docs consistent with CONTRIBUTING guidance

## Testing
- dotnet test FlowSynx.sln *(fails: installed SDK is 8.0.415 while the solution targets net9.0)*

Fixes #703