### PR TITLE
Refine latest plugin version resolution (#717)

### DIFF
--- a/src/FlowSynx.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/FlowSynx.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ public static class ServiceCollectionExtensions
         services
             .AddSingleton<IPluginCacheService, PluginCacheService>()
             .AddScoped<IPluginDownloader, PluginDownloader>()
+            .AddScoped<IPluginVersionResolver, PluginVersionResolver>()
             .AddScoped<IPluginManager, PluginManager>()
             .AddSingleton<IPluginCacheKeyGeneratorService, PluginCacheKeyGeneratorService>()
             .AddScoped<IPluginTypeService, PluginTypeService>()

--- a/src/FlowSynx.Infrastructure/PluginHost/Manager/IPluginVersionResolver.cs
+++ b/src/FlowSynx.Infrastructure/PluginHost/Manager/IPluginVersionResolver.cs
@@ -1,0 +1,21 @@
+namespace FlowSynx.Infrastructure.PluginHost.Manager;
+
+/// <summary>
+/// Resolves the effective plugin version to install based on the registry state.
+/// </summary>
+public interface IPluginVersionResolver
+{
+    /// <summary>
+    /// Resolves the version string that should be used for installation.
+    /// </summary>
+    /// <param name="registryUrl">The configured plugin registry base url.</param>
+    /// <param name="pluginType">The plugin identifier.</param>
+    /// <param name="requestedVersion">The requested version or <c>latest</c>.</param>
+    /// <param name="cancellationToken">Cancellation token propagated from the request.</param>
+    /// <returns>The resolved version string that exists in the registry.</returns>
+    Task<string> ResolveVersionAsync(
+        string registryUrl,
+        string pluginType,
+        string? requestedVersion,
+        CancellationToken cancellationToken);
+}

--- a/src/FlowSynx.Infrastructure/PluginHost/Manager/PluginVersionResolver.cs
+++ b/src/FlowSynx.Infrastructure/PluginHost/Manager/PluginVersionResolver.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FlowSynx.Application.Models;
+using FlowSynx.PluginCore.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace FlowSynx.Infrastructure.PluginHost.Manager;
+
+/// <summary>
+/// Default implementation for determining the effective plugin version the manager should install.
+/// </summary>
+public class PluginVersionResolver : IPluginVersionResolver
+{
+    private readonly IPluginDownloader _pluginDownloader;
+    private readonly ILogger<PluginVersionResolver> _logger;
+
+    public PluginVersionResolver(
+        IPluginDownloader pluginDownloader,
+        ILogger<PluginVersionResolver> logger)
+    {
+        ArgumentNullException.ThrowIfNull(pluginDownloader);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        _pluginDownloader = pluginDownloader;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> ResolveVersionAsync(
+        string registryUrl,
+        string pluginType,
+        string? requestedVersion,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedVersion) &&
+            !requestedVersion.Equals("latest", StringComparison.OrdinalIgnoreCase))
+        {
+            return requestedVersion;
+        }
+
+        var versions = await _pluginDownloader.GetPluginVersionsAsync(registryUrl, pluginType, cancellationToken);
+        var resolvedVersion = TrySelectVersionByIsLatest(versions) ??
+                              TrySelectVersionByValue(versions);
+
+        if (string.IsNullOrWhiteSpace(resolvedVersion))
+        {
+            throw new FlowSynxException(
+                (int)ErrorCode.PluginNotFound,
+                $"No available versions found for plugin '{pluginType}'.");
+        }
+
+        _logger.LogInformation("Resolved latest version for plugin {PluginType}: {Version}", pluginType, resolvedVersion);
+        return resolvedVersion;
+    }
+
+    private static string? TrySelectVersionByIsLatest(IEnumerable<PluginVersion>? versions)
+    {
+        return versions?
+            .FirstOrDefault(v => v.IsLatest == true)?
+            .Version;
+    }
+
+    private static string? TrySelectVersionByValue(IEnumerable<PluginVersion>? versions)
+    {
+        return versions?
+            .Where(v => !string.IsNullOrWhiteSpace(v.Version))
+            .Select(v => new
+            {
+                Raw = v.Version!,
+                Parsed = Version.TryParse(v.Version, out var parsed) ? parsed : null
+            })
+            .OrderByDescending(item => item.Parsed is not null)
+            .ThenByDescending(item => item.Parsed)
+            .ThenByDescending(item => item.Raw, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault()
+            ?.Raw;
+    }
+}

--- a/tests/FlowSynx.Infrastructure.UnitTests/PluginHost/Manager/PluginVersionResolverTests.cs
+++ b/tests/FlowSynx.Infrastructure.UnitTests/PluginHost/Manager/PluginVersionResolverTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FlowSynx.Application.Models;
+using FlowSynx.Infrastructure.PluginHost.Manager;
+using FlowSynx.PluginCore.Exceptions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace FlowSynx.Infrastructure.UnitTests.PluginHost.Manager;
+
+public class PluginVersionResolverTests
+{
+    [Fact]
+    public async Task ResolveVersionAsync_ReturnsExplicitVersion_WhenProvided()
+    {
+        var downloaderMock = new Mock<IPluginDownloader>(MockBehavior.Strict);
+        var resolver = CreateResolver(downloaderMock);
+
+        var version = await resolver.ResolveVersionAsync("https://registry", "TestPlugin", "2.0.0", CancellationToken.None);
+
+        Assert.Equal("2.0.0", version);
+        downloaderMock.Verify(d => d.GetPluginVersionsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveVersionAsync_UsesIsLatestFlag_WhenAvailable()
+    {
+        var downloaderMock = new Mock<IPluginDownloader>(MockBehavior.Strict);
+        downloaderMock
+            .Setup(d => d.GetPluginVersionsAsync("https://registry", "TestPlugin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new PluginVersion { Version = "1.0.0" },
+                new PluginVersion { Version = "2.5.0", IsLatest = true }
+            });
+        var resolver = CreateResolver(downloaderMock);
+
+        var version = await resolver.ResolveVersionAsync("https://registry", "TestPlugin", "latest", CancellationToken.None);
+
+        Assert.Equal("2.5.0", version);
+        downloaderMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ResolveVersionAsync_FallsBackToHighestSemanticVersion()
+    {
+        var downloaderMock = new Mock<IPluginDownloader>(MockBehavior.Strict);
+        downloaderMock
+            .Setup(d => d.GetPluginVersionsAsync("https://registry", "TestPlugin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new PluginVersion { Version = "0.9.0" },
+                new PluginVersion { Version = "1.10.0" },
+                new PluginVersion { Version = "2.0.0" }
+            });
+        var resolver = CreateResolver(downloaderMock);
+
+        var version = await resolver.ResolveVersionAsync("https://registry", "TestPlugin", null, CancellationToken.None);
+
+        Assert.Equal("2.0.0", version);
+        downloaderMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ResolveVersionAsync_UsesAlphabeticalOrder_WhenNoSemanticVersionExists()
+    {
+        var downloaderMock = new Mock<IPluginDownloader>(MockBehavior.Strict);
+        downloaderMock
+            .Setup(d => d.GetPluginVersionsAsync("https://registry", "TestPlugin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[]
+            {
+                new PluginVersion { Version = "beta" },
+                new PluginVersion { Version = "alpha" }
+            });
+        var resolver = CreateResolver(downloaderMock);
+
+        var version = await resolver.ResolveVersionAsync("https://registry", "TestPlugin", "latest", CancellationToken.None);
+
+        Assert.Equal("beta", version);
+        downloaderMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ResolveVersionAsync_Throws_WhenRegistryHasNoVersions()
+    {
+        var downloaderMock = new Mock<IPluginDownloader>(MockBehavior.Strict);
+        downloaderMock
+            .Setup(d => d.GetPluginVersionsAsync("https://registry", "TestPlugin", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<PluginVersion>());
+        var resolver = CreateResolver(downloaderMock);
+
+        var exception = await Assert.ThrowsAsync<FlowSynxException>(() =>
+            resolver.ResolveVersionAsync("https://registry", "TestPlugin", "latest", CancellationToken.None));
+
+        Assert.Equal((int)ErrorCode.PluginNotFound, exception.ErrorCode);
+        downloaderMock.VerifyAll();
+    }
+
+    private static PluginVersionResolver CreateResolver(Mock<IPluginDownloader> downloaderMock)
+    {
+        return new PluginVersionResolver(downloaderMock.Object, Mock.Of<ILogger<PluginVersionResolver>>());
+    }
+}


### PR DESCRIPTION
## Summary
Closes #717. This change keeps plugin installs aligned with our conventions by resolving the "latest" placeholder before any registry calls and documenting the behavior with tests.

## Implementation Notes
- Introduced `IPluginVersionResolver`/`PluginVersionResolver` with XML doc comments so the logic can be tested in isolation and reused anywhere we need dynamic version discovery.
- Updated `PluginManager` to depend on the resolver instead of a private helper and registered it in `AddPluginManager`, keeping dependency wiring consistent with the rest of the infrastructure layer.
- Added `PluginVersionResolverTests` that cover `IsLatest`, semantic comparison, string fallback, and the error path when the registry returns no versions, ensuring regressions will be caught early.

## Testing
- `dotnet test tests/FlowSynx.Infrastructure.UnitTests/FlowSynx.Infrastructure.UnitTests.csproj` *(fails: local SDK is 8.0.415 and cannot restore the repo that targets net9.0; run with .NET 9 SDK installed to verify on CI)*
