### PR TITLE
Refactor JWT provider loop to use LINQ Select

### DIFF
--- a/src/FlowSynx.Application/Configuration/Core/Security/AuthenticationConfiguration.cs
+++ b/src/FlowSynx.Application/Configuration/Core/Security/AuthenticationConfiguration.cs
@@ -1,7 +1,6 @@
 ﻿using FlowSynx.Application.Models;
 using FlowSynx.PluginCore.Exceptions;
 using Microsoft.Extensions.Logging;
-
 namespace FlowSynx.Application.Configuration.Core.Security;
 
 public class AuthenticationConfiguration
@@ -38,11 +37,12 @@ public class AuthenticationConfiguration
             logger.LogInformation("Basic authentication is enabled.");
         }
 
-        foreach (var jwt in JwtProviders)
+        foreach (var scheme in JwtProviders.Select(jwt => jwt.Name))
         {
-            validSchemes.Add(jwt.Name);
-            logger.LogInformation("JWT provider '{Scheme}' configured", jwt.Name);
+            validSchemes.Add(scheme);
+            logger.LogInformation("JWT provider '{Scheme}' configured", scheme);
         }
+
 
         return validSchemes;
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

This PR refactors the loop over `JwtProviders` in `AuthenticationConfiguration`
to use `JwtProviders.Select(jwt => jwt.Name)`.

This improves readability, reduces boilerplate, and makes the intent
(extracting provider names) clearer.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Closes #723 

## Checklist

Please make sure you've  completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [X] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in flowsynx/website#<issue-number>
* [ ] Specification has been updated / Created issue in flowsynx/website#<issue-number>
* [ ] Provided sample for the feature / Created issue in flowsynx/website#<issue-number>
