### PR TITLE
Fix structured logging in AuditsListHandler

### DIFF
--- a/src/FlowSynx.Application/Features/Audit/Query/AuditsList/AuditsListHandler.cs
+++ b/src/FlowSynx.Application/Features/Audit/Query/AuditsList/AuditsListHandler.cs
@@ -60,7 +60,7 @@ internal class AuditsListHandler : IRequestHandler<AuditsListRequest, PaginatedR
         }
         catch (FlowSynxException ex)
         {
-            _logger.LogError(ex.ToString());
+            _logger.LogError(ex, "FlowSynxException caught while retrieving the audit list.");
             return await PaginatedResult<AuditsListResponse>.FailureAsync(ex.ToString());
         }
     }


### PR DESCRIPTION
## Summary
- replace the raw `ex.ToString()` logging with `LogError(Exception, message)` so providers capture stack traces, scopes, and properties consistently with the rest of FlowSynx
- keep the handler response contract intact while emitting a descriptive message about audit retrieval failures

## Testing
- dotnet test FlowSynx.sln

Closes #725.