### PR TITLE
Use structured logging in SummaryHandler

### DIFF
--- a/src/FlowSynx.Application/Features/Metrics/Query/SummaryHandler.cs
+++ b/src/FlowSynx.Application/Features/Metrics/Query/SummaryHandler.cs
@@ -49,8 +49,8 @@ internal class SummaryHandler : IRequestHandler<SummaryRequest, Result<SummaryRe
         }
         catch (FlowSynxException ex)
         {
-            _logger.LogError(ex.ToString());
-            return await Result<SummaryResponse>.FailAsync(ex.ToString());
+            _logger.LogError(ex, "FlowSynx exception caught in SummaryHandler.");
+            return await Result<SummaryResponse>.FailAsync(ex.Message);
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch SummaryHandler to log FlowSynxException with the structured LogError overload and a clear message instead of calling ToString()
- return the failure response with the exception message so clients see the intended error text without the formatted stack trace
- aligns logging with the rest of the codebase and closes #743

## Testing
- dotnet test FlowSynx.sln