### PR TITLE
Use structured logging in AddPluginConfigHandler

### DIFF
--- a/src/FlowSynx.Application/Features/PluginConfig/Command/AddPluginConfig/AddPluginConfigHandler.cs
+++ b/src/FlowSynx.Application/Features/PluginConfig/Command/AddPluginConfig/AddPluginConfigHandler.cs
@@ -98,8 +98,8 @@ internal class AddPluginConfigHandler : IRequestHandler<AddPluginConfigRequest, 
         }
         catch (FlowSynxException ex)
         {
-            _logger.LogError(ex.ToString());
-            return await Result<AddPluginConfigResponse>.FailAsync(ex.ToString());
+            _logger.LogError(ex, "FlowSynx exception caught while adding plugin configuration.");
+            return await Result<AddPluginConfigResponse>.FailAsync(ex.Message);
         }
     }
 }


### PR DESCRIPTION
## Summary
- log FlowSynxException via structured LogError overload with a descriptive message in AddPluginConfigHandler
- return failure result with the exception message instead of ToString() to keep responses concise and consistent
- aligns exception handling with project logging conventions and closes #744

## Testing
- dotnet test FlowSynx.sln