### PR TITLE
Use InvalidOperationException for workflow retry validation (#766)

### DIFF
--- a/src/FlowSynx.Infrastructure/Workflow/WorkflowValidator.cs
+++ b/src/FlowSynx.Infrastructure/Workflow/WorkflowValidator.cs
@@ -104,7 +104,7 @@ public class WorkflowValidator : IWorkflowValidator
 
         if (errors.Any())
         {
-            throw new Exception(string.Join(Environment.NewLine, errors));
+            throw new InvalidOperationException(string.Join(Environment.NewLine, errors));
         }
     }
 

--- a/tests/FlowSynx.Infrastructure.UnitTests/Workflow/WorkflowValidatorTests.cs
+++ b/tests/FlowSynx.Infrastructure.UnitTests/Workflow/WorkflowValidatorTests.cs
@@ -161,5 +161,34 @@ namespace FlowSynx.Tests.Infrastructure.Workflow
 
             Assert.Null(exception);
         }
+
+        [Fact]
+        public async Task Validate_Should_Throw_InvalidOperation_When_RetryPolicy_Invalid()
+        {
+            var tasks = new List<WorkflowTask>
+            {
+                new("TaskA")
+                {
+                    ErrorHandling = new ErrorHandling
+                    {
+                        RetryPolicy = new RetryPolicy
+                        {
+                            MaxRetries = -1
+                        }
+                    }
+                }
+            };
+
+            var definition = new WorkflowDefinition
+            {
+                Name = "Workflow With invalid retry policy",
+                Tasks = tasks
+            };
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await _validator.ValidateAsync(definition));
+
+            Assert.Contains("WorkflowValidator_TaskHasNegativeMaxRetries", exception.Message);
+        }
     }
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

- replace the generic `Exception` thrown when retry validation fails with `InvalidOperationException` to surface a more specific, meaningful error type during workflow validation
- keep validation messaging intact while aligning with the project's structured exception handling inside `WorkflowValidator`
- add a workflow validator unit test covering invalid retry policy configuration and confirming the new exception type/message

## Issue reference

Closes #766

## Checklist

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Unit tests passing
* [ ] End-to-end tests passing
* [ ] Extended the documentation / Created issue in flowsynx/website#<issue-number>
* [ ] Specification has been updated / Created issue in flowsynx/website#<issue-number>
* [ ] Provided sample for the feature / Created issue in flowsynx/website#<issue-number>