### PR TITLE
Use InvalidOperationException when Infisical secret retrieval fails

### DIFF
--- a/src/FlowSynx.Infrastructure/Secrets/Infisical/InfisicalSecretProvider.cs
+++ b/src/FlowSynx.Infrastructure/Secrets/Infisical/InfisicalSecretProvider.cs
@@ -48,7 +48,7 @@ public class InfisicalSecretProvider : ISecretProvider, IConfigurableSecret
             var message = $"Error retrieving configuration secrets from Infisical for environment '{environment}'.";
             _logger?.LogWarning(ex, message);
 
-            throw new Exception(message, ex);
+            throw new InvalidOperationException(message, ex);
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace the generic Exception wrapper in InfisicalSecretProvider with InvalidOperationException so callers receive a meaningful failure type when secret retrieval fails. Closes #768.
- Preserve the existing log context to remain consistent with the provider's validation paths.

## Testing
- Not run (not requested).