### PR TITLE
Fix logging to include exceptions in WorkflowExecutionService

### DIFF
--- a/src/FlowSynx.Persistence/FlowSynx.Persistence.Postgres/Services/WorkflowExecutionService.cs
+++ b/src/FlowSynx.Persistence/FlowSynx.Persistence.Postgres/Services/WorkflowExecutionService.cs
@@ -39,7 +39,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         catch (Exception ex)
         {
             var errorMessage = new ErrorMessage((int)ErrorCode.WorkflowsGetExecutionList, ex.Message);
-            _logger.LogError(errorMessage.ToString());
+            _logger.LogError(ex, errorMessage.ToString());
             throw new FlowSynxException(errorMessage);
         }
     }
@@ -61,7 +61,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         catch (Exception ex)
         {
             var errorMessage = new ErrorMessage((int)ErrorCode.WorkflowGetExecutionItem, ex.Message);
-            _logger.LogError(errorMessage.ToString());
+            _logger.LogError(ex, errorMessage.ToString());
             throw new FlowSynxException(errorMessage);
         }
     }
@@ -81,7 +81,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         catch (Exception ex)
         {
             var errorMessage = new ErrorMessage((int)ErrorCode.WorkflowExecutionCheckExistence, ex.Message);
-            _logger.LogError(errorMessage.ToString());
+            _logger.LogError(ex, errorMessage.ToString());
             throw new FlowSynxException(errorMessage);
         }
     }
@@ -102,7 +102,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         catch (Exception ex)
         {
             var errorMessage = new ErrorMessage((int)ErrorCode.WorkflowExecutionAdd, ex.Message);
-            _logger.LogError(errorMessage.ToString());
+            _logger.LogError(ex, errorMessage.ToString());
             throw new FlowSynxException(errorMessage);
         }
     }
@@ -122,7 +122,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         catch (Exception ex)
         {
             var errorMessage = new ErrorMessage((int)ErrorCode.WorkflowExecutionUpdate, ex.Message);
-            _logger.LogError(errorMessage.ToString());
+            _logger.LogError(ex, errorMessage.ToString());
             throw new FlowSynxException(errorMessage);
         }
     }
@@ -143,7 +143,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         catch (Exception ex)
         {
             var errorMessage = new ErrorMessage((int)ErrorCode.WorkflowExecutionDelete, ex.Message);
-            _logger.LogError(errorMessage.ToString());
+            _logger.LogError(ex, errorMessage.ToString());
             throw new FlowSynxException(errorMessage);
         }
     }
@@ -175,7 +175,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex.Message.ToString());
+            _logger.LogError(ex, ex.Message.ToString());
             return 0;
         }
     }
@@ -197,7 +197,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex.Message.ToString());
+            _logger.LogError(ex, ex.Message.ToString());
             return 0;
         }
     }
@@ -216,7 +216,7 @@ public class WorkflowExecutionService : IWorkflowExecutionService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex.Message.ToString());
+            _logger.LogError(ex, ex.Message.ToString());
             return 0;
         }
     }


### PR DESCRIPTION
## Summary
- pass the caught exception into _logger.LogError across WorkflowExecutionService catch blocks so stack traces are preserved and logging matches other services
- align the count helper methods to log the exception and message together, keeping error handling consistent with the rest of the persistence layer

## Testing
- dotnet test FlowSynx.sln *(fails: local .NET SDK 9.0.307 cannot target net10.0; needs newer SDK to run suite)*

Closes #785.