### PR TITLE
Fix Key Vault secret enabled guard

### DIFF
--- a/src/FlowSynx.Infrastructure/Secrets/AzureKeyVault/AzureKeyVaultSecretProvider.cs
+++ b/src/FlowSynx.Infrastructure/Secrets/AzureKeyVault/AzureKeyVaultSecretProvider.cs
@@ -42,7 +42,7 @@ public class AzureKeyVaultSecretProvider : ISecretProvider, IConfigurableSecret
                 cancellationToken.ThrowIfCancellationRequested();
 
                 // Skip disabled or deleted secrets
-                if (secretProperties.Enabled != true)
+                if (secretProperties.Enabled is not true)
                     continue;
 
                 try


### PR DESCRIPTION
## Summary\n- simplify the Key Vault secret enabled guard to drop the redundant boolean literal while retaining the existing null/disabled handling\n- no functional change: disabled or deleted secrets still short-circuit before retrieval, keeping the logging flow intact\n\n## Testing\n- dotnet test *(fails: local .NET SDK 10.0 not installed; projects target net10.0)*\n\nCloses #784.