### PR TITLE
Remove boolean literal comparisons in workflow trigger queries

### DIFF
--- a/src/FlowSynx.Persistence/FlowSynx.Persistence.Postgres/Services/WorkflowTriggerService.cs
+++ b/src/FlowSynx.Persistence/FlowSynx.Persistence.Postgres/Services/WorkflowTriggerService.cs
@@ -28,7 +28,7 @@ public class WorkflowTriggerService : IWorkflowTriggerService
         {
             await using var context = await _appContextFactory.CreateDbContextAsync(cancellationToken);
             var result = await context.WorkflowTriggeres
-                .Where(x => x.IsDeleted == false)
+                .Where(x => !x.IsDeleted)
                 .ToListAsync(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
@@ -50,7 +50,7 @@ public class WorkflowTriggerService : IWorkflowTriggerService
         {
             await using var context = await _appContextFactory.CreateDbContextAsync(cancellationToken);
             var result = await context.WorkflowTriggeres
-                .Where(x => x.IsDeleted == false && x.WorkflowId == workflowId)
+                .Where(x => !x.IsDeleted && x.WorkflowId == workflowId)
                 .ToListAsync(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
@@ -72,7 +72,7 @@ public class WorkflowTriggerService : IWorkflowTriggerService
         {
             await using var context = await _appContextFactory.CreateDbContextAsync(cancellationToken);
             var result = await context.WorkflowTriggeres
-                .Where(x => x.Type == type && x.Status == WorkflowTriggerStatus.Active && x.IsDeleted == false)
+                .Where(x => x.Type == type && x.Status == WorkflowTriggerStatus.Active && !x.IsDeleted)
                 .ToListAsync(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
@@ -95,7 +95,7 @@ public class WorkflowTriggerService : IWorkflowTriggerService
         {
             await using var context = await _appContextFactory.CreateDbContextAsync(cancellationToken);
             return await context.WorkflowTriggeres
-                .FirstOrDefaultAsync(x => x.Id == triggerId && x.WorkflowId == workflowId && x.IsDeleted == false, cancellationToken)
+                .FirstOrDefaultAsync(x => x.Id == triggerId && x.WorkflowId == workflowId && !x.IsDeleted, cancellationToken)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- Replace boolean literal comparisons in workflow trigger queries with direct negation to align with C# and EF Core conventions.
## Changes
- Updated LINQ filters in WorkflowTriggerService to use !x.IsDeleted instead of x.IsDeleted == false.
- Kept query semantics intact while improving readability and reducing static analysis noise.
## Testing
- Not run (query refactor only).
## Issue
- Closes #795.